### PR TITLE
alloc-free gojay, parallel benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@
 - Test reusage
 - `ToJSON()`: use bytebufferpool? Impossible for now because we should not store results of `ToJSON()`
 - The only way to modify an element of array of nested objects - is to read all elements to `[]*Buffer` using `GetByIndex()` (not `ObjectArray`!), modify, then `Set(name, []*Buffer))`
+- Pooled `ObjectArray`
 
 
 # Benchmarks

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
   - `int32, int64, float32, float64, bool, string, byte`
   - nested objects
   - arrays
-- Empty nested objects and arrays are not stored
+- Empty strings, nested objects and arrays are not stored (`Get()` returns nil)
+- Strings could be set as both `string` and `[]byte`, string arrays - as both `[]string` and `[][]byte`. `Get()`, `ToJSON()` and `ToJSONMap()` returns string or array of strings
 - Scheme versioning
   - Any data written with Scheme of any version will be correctly read using Scheme of any other version
     - Written in old Scheme, read in New Scheme -> nil result on new field read, field considered as unset
@@ -289,22 +290,12 @@
  - Empty array -> no array, `Get()` will return nil, `HasValue()` will return false
  - See [dynobuffers_test.go](dynobuffers_test.go) for usage examples
 
-# New
-- ObjectArray elements should not be modified
--
--
-
 # TODO
-- Current `gojay` implementation is not optimal when reading JSON values which could be null: provide `**int32`, null met  -> ptr is untouched, value met -> `new(int32)` is executed which means memory allocation. Also difference between null and non-int is not tracked: no error if e.g. expecting number but string is met. The better approach would be to implement methods like `Int32OrNull() (val int32, isNull bool)`. See `bufferSlice.UnmarshalJSONObject()` and `Buffer.UnmarshalJSONObject()`
-  - Not done: detecting if object array is null in JSON provided to `ApplyJSONAndToBytes()`. See `TestApplyJSONArrays()`
 - For now there are 2 same methods: `ApplyMapBuffer()` and `ApplyJSONAndToBytes()`. Need to get rid of one of them.
 - For now `ToBytes()` result must not be stored if `Release()` is used because on next `ToBytes()` the stored previous `ToBytes()` result will be damaged. See `TestPreviousResultDamageOnReuse()`. The better soultion is to make `ToBytes()` return not `[]byte` but an `interface {Bytes() []byte; Release()}`.
   - use [bytebufferpool](https://github.com/valyala/bytebufferpool) on `flatbuffers.Builder.Bytes`?
-- Test reusage
-- `ToJSON()`: use bytebufferpool? Impossible for now because we should not store results of `ToJSON()`
+- `ToJSON()`: use bytebufferpool? 
 - The only way to modify an element of array of nested objects - is to read all elements to `[]*Buffer` using `GetByIndex()` (not `ObjectArray`!), modify, then `Set(name, []*Buffer))`
-- Pooled `ObjectArray`
-
 
 # Benchmarks
 

--- a/benchmarks/bench.md
+++ b/benchmarks/bench.md
@@ -59,3 +59,36 @@ BenchmarkWriteSimple_Avro-8                                      2122617        
 PASS
 ok      github.com/Yohanson555/dynobuffers/benchmarks   36.061s
 ```
+
+## After fix + parallel
+
+```
+goos: windows
+goarch: amd64
+pkg: github.com/untillpro/dynobuffers/benchmarks
+BenchmarkWriteDynoBuffersSimpleTyped-4                          10208407               126 ns/op               0 B/op          0 allocs/op
+BenchmarkWriteDynoBuffersSimpleTypedReadWriteString-4            9448275               160 ns/op               0 B/op          0 allocs/op
+BenchmarkWriteDynoBuffersSimpleUntyped-4                         8572695               135 ns/op               4 B/op          1 allocs/op
+BenchmarkWriteFlatBuffersSimple-4                               19998866                50.2 ns/op             0 B/op          0 allocs/op
+BenchmarkWriteJsonSimple-4                                        619281              2049 ns/op            1360 B/op         35 allocs/op
+BenchmarkWriteLinkedInAvroSimple-4                               1804407               754 ns/op             752 B/op         10 allocs/op
+BenchmarkWriteDynoBuffersArticleReadFewFieldsTyped-4            21427346                47.0 ns/op             0 B/op          0 allocs/op
+BenchmarkWriteFlatBuffersArticleReadFewFields-4                   333314              3939 ns/op            3640 B/op         18 allocs/op
+BenchmarkWriteJsonArticleReadFewFields-4                           12564             96710 ns/op           46670 B/op        870 allocs/op
+BenchmarkWriteLinkedInAvroArticleReadFewFields-4                   94482             14088 ns/op           11154 B/op         76 allocs/op
+BenchmarkWriteFlatBuffersArticleReadAllFields-4                   461511              4260 ns/op            3640 B/op         18 allocs/op
+BenchmarkWriteJsonArticleReadAllFields-4                           12034            105042 ns/op           46599 B/op        869 allocs/op
+BenchmarkWriteNestedSimple_Dyno-4                                 521707              2404 ns/op            1121 B/op         10 allocs/op
+BenchmarkWriteNestedSimple_Dyno_SameBuilder-4                     521709              2360 ns/op            1121 B/op         10 allocs/op
+BenchmarkWriteNestedSimple_ApplyMap_Test-4                       2289945               509 ns/op               0 B/op          0 allocs/op
+BenchmarkWriteNested_ToBytes_Test-4                               999940              1595 ns/op            1120 B/op         10 allocs/op
+BenchmarkWriteDynoBufferArticleReadAllFieldsUntyped-4             331902              3595 ns/op             352 B/op         25 allocs/op
+BenchmarkWriteDynoBufferArticleReadAllFieldsTyped-4               410910              2957 ns/op               0 B/op          0 allocs/op
+BenchmarkWriteSimple_Dyno_SameBuilder-4                          9022040               123 ns/op               0 B/op          0 allocs/op
+BenchmarkWriteSimple_Dyno-4                                     10618857               116 ns/op               0 B/op          0 allocs/op
+BenchmarkWriteSimple_Avro-4                                      3895880               277 ns/op             336 B/op          2 allocs/op
+BenchmarkWriteNestedSimple_ApplyMap_withJSONUnmarshal-4           111104             11602 ns/op            6423 B/op         84 allocs/op
+BenchmarkWriteNestedSimple_ApplyMapBuffer-4                       479971              2402 ns/op             416 B/op         13 allocs/op
+PASS
+ok      github.com/untillpro/dynobuffers/benchmarks     38.673s
+```

--- a/benchmarks/benchData.go
+++ b/benchmarks/benchData.go
@@ -412,3 +412,412 @@ func getArticleSchemeDynoBuffer() *dynobuffers.Scheme {
 	s.AddField("id_size_modifier", dynobuffers.FieldTypeLong, false)
 	return s
 }
+
+var pbillYaml string = `
+Id: long
+Id_bill: long
+Id_untill_users: long
+number: int
+failurednumber: int
+suffix: string
+pdatetime: string
+id_sales_area: long
+pcname: string
+service_charge: double
+real_datetime: string
+tips: float
+id_clients: long
+pbill_index: int
+split_parts: double
+id_real_untill_user: long
+reopen_type: byte
+external_id: string
+covers: int
+hht: string
+super_dx: long
+c_tips: float
+id_currency: long
+bill:
+  Id: long
+  Tableno: int
+  Id_untill_users: long
+  Table_part: string
+  id_courses: long
+  id_clients: long
+  name: string
+  Proforma: byte
+  modified: string
+  open_datetime: string
+  close_datetime: string
+  number: int
+  failurednumber: int
+  suffix: string
+  pbill_number: int
+  pbill_failurednumber: int
+  pbill_suffix: string
+  hc_foliosequence: int
+  hc_folionumber: string
+  tip: float
+  qty_persons: int
+  isdirty: byte
+  reservationid: string
+  id_alter_user: long
+  service_charge: double
+  number_of_covers: int
+  id_user_proforma: long
+  bill_type: byte
+  locker: int
+  id_time_article: long
+  timer_start: string
+  timer_stop: string
+  isactive: byte
+  table_name: string
+  group_vat_level: byte
+  comments: string
+  id_cardprice: long
+  discount: double
+  discount_value: float
+  id_discount_reasons: long
+  hc_roomnumber: string
+  ignore_auto_sc: byte
+  extra_fields..: byte
+  id_bo_service_charge: long
+  free_comments: string
+  id_t2o_groups: long
+  service_tax: float
+  sc_plan..: byte
+  client_phone: string
+  age: string
+  description..: byte
+  sdescription: string
+  vars..: byte
+  take_away: int
+  fiscal_number: int
+  fiscal_failurednumber: int
+  fiscal_suffix: string
+  id_order_type: long
+  not_paid: float
+  total: float
+bill_reprints..:
+  Id: long
+  Id_pbill: long
+  datetime: string
+  id_untill_users: long
+bill_split_rest..:
+  Id: long
+  id_bill: long
+  is_active: byte
+  split_data..: byte
+  datetime: string
+  id_pbill: long
+complete_meal..:
+  Id: long
+  id_pbill: long
+  id_untill_users: long
+  cm_datetime: string
+  cm_pcname: string
+  cm_quantity: int
+  cm_price: float
+neg_pbill..:
+  Id: long
+  Id_pbill: long
+  R_type: byte
+  pdatetime: string
+  id_pbill_close: long
+open_discounts..:
+  Id: long
+  Id_pbill: long
+  amount: float
+  vat_percent: float
+  vat: double
+pbill_balance..:
+  Id: long
+  id_pbill: long
+  id_clients: long
+  id_accounts: long
+  pre_balance: float
+  pre_balance_common: float
+pbill_cleancash_info..:
+  Id: long
+  id_pbill: long
+  clean_cash_trnumber: long
+  clean_cash_signature: string
+  manufacturing_code: string
+  control_timestamp: string
+  ticket_counter: string
+  vsc_id: string
+  plu_data_hash: string
+  id_bill: long
+  ccdatetime: string
+  kind: byte
+  production_nr: string
+  extra1: string
+  extra2: string
+pbill_email..:
+  Id: long
+  id_pbill: long
+  pemail_email: string
+  pemail_body..: byte
+  pemail_dt: string
+  pemail_state: byte
+pbill_item..:
+  Id: long
+  Id_pbill: long
+  Id_untill_users: long
+  Tableno: int
+  Rowbeg: byte
+  Kind: byte
+  Quantity: int
+  id_articles: long
+  Price: float
+  text: string
+  id_prices: long
+  with_without: int
+  id_courses: long
+  pdatetime: string
+  purchase_price: float
+  vat_sign: string
+  vat: double
+  id_menu: long
+  menu_quantity: int
+  original_price: float
+  id_discount_reasons: long
+  discount_type: int
+  chair_number: int
+  separated: byte
+  negative: byte
+  vat_percent: float
+  chair_name: string
+  id_option_article: long
+  start_delay_minutes: int
+  pua: byte
+  no_price: byte
+  orig_pbill_id: long
+  parts_id: long
+  full_paid: byte
+  weight: float
+  splitted_coef: double
+  split_id: long
+  free_comments: string
+  id_smartcards: long
+  has_allergens: byte
+  id_article_options: long
+  order_item_allergens..:
+    Id: long
+    id_order_item: long
+    id_menu_item: long
+    id_allergens: long
+    text: string
+    id_pbill_item: long
+  order_item_extra..:
+    Id: long
+    id_order_item: long
+    id_menu_item: long
+    id_pbill_item: long
+    id_article_barcodes: long
+  order_item_sizes..:
+    Id: long
+    id_order_item: long
+    id_menu_item: long
+    id_pbill_item: long
+    id_articles: long
+    price: float
+    original_price: float
+    vat: double
+    id_size_modifier_item: long
+  pbill_hash..:
+    Id: long
+    Id_pbill_item: long
+    Id_untill_users: long
+  pbill_item_bookp..:
+    Id: long
+    id_pbill_item: long
+    id_bookkeeping_turnover: long
+    id_bookkeeping_vat: long
+pbill_item_refund..:
+  Id: long
+  Id_pbill: long
+  Id_untill_users: long
+  Tableno: int
+  Rowbeg: byte
+  Kind: byte
+  Quantity: int
+  id_articles: long
+  id_department: long
+  id_food_group: long
+  id_category: long
+  Price: float
+  text: string
+  id_prices: long
+  with_without: int
+  id_courses: long
+  pdatetime: string
+  purchase_price: float
+  vat_sign: string
+  vat: double
+  id_menu: long
+  menu_quantity: int
+  ref_type: byte
+pbill_payments..:
+  Id: long
+  Id_pbill: long
+  Id_payments: long
+  Price: float
+  customer_amount: float
+  c_price: float
+  c_customer_amount: float
+  vat: float
+  id_driver_discount: long
+  accounts_payments..:
+    Id: long
+    datetime: string
+    Id_clients: long
+    Id_untill_users: long
+    tableno: int
+    tablepart: string
+    number: int
+    suffix: string
+    name: string
+    tr_datetime: string
+    bill_number: string
+    parts_count: byte
+    part_index: byte
+    discount: double
+    id_sales_area: long
+    total: float
+    account_type: byte
+    payer_name: string
+    id_pbill_payments: long
+  account_payment_data..:
+    Id: long
+    id_pbill_payments: long
+    account_type: byte
+  payments_hash..:
+    Id: long
+    Id_payments: long
+    Id_untill_users: long
+  pbill_card_payments_info..:
+    Id: long
+    Id_pbill_payments: long
+    masked_pan: string
+    pan: string
+    expire: string
+    auth_number: string
+    acquier_code: string
+    field1: string
+    field2: string
+    field3: string
+    field4: string
+    field5: string
+    track2data: string
+    loyaltyamount: long
+    controlno: string
+    chargetype: int
+    cardname: string
+    cardnoentertype: int
+    terminalid: string
+    aid: string
+    tvr: string
+    tsi: string
+    account_type: string
+    customer_receipt: string
+    merchant_receipt: string
+    tip_approvement: byte
+    prepaid_pan: string
+    misc_data..: byte
+    field6: string
+    field7: string
+    field8: string
+    field9: string
+    field10: string
+    merchant_id: string
+    cashback_amount: long
+    field11: string
+    field12: string
+    field13: string
+    field14: string
+    field15: string
+  pbill_payer..:
+    Id: long
+    id_pbill_payments: long
+    payer_name: string
+  pbill_payments_bookp..:
+    Id: long
+    id_pbill_payments: long
+    id_bookkeeping: long
+  pbill_zapper_payments_info..:
+    Id: long
+    Id_pbill_payments: long
+    Id_zapper_proformas: long
+    zapper_id: string
+    misc_data..: byte
+  psp_tips..:
+    Id: long
+    Id_pbill: long
+    amount: float
+    id_pbill_payments: long
+  smartcards_turnover..:
+    Id: long
+    datetime: string
+    Id_smartcards: long
+    Id_untill_users: long
+    kind: byte
+    amount: float
+    p_amount: float
+    id_pbill_payments: long
+    id_payments: long
+    is_initial_value: byte
+    card_data..: byte
+    deposit_number: int
+    deposit_suffix: string
+    pcname: string
+    new_balance: float
+  voucher_payments..:
+    Id: long
+    id_vouchers: long
+    id_pbill_payments: long
+    used_dt: string
+  voucher_pbill_payments..:
+    Id: long
+    id_voucher_pbill: long
+    price: float
+    id_vouchers: long
+    id_payments: long
+    id_pbill_payments: long
+pbill_return..:
+  Id: long
+  id_pbill: long
+  ref_type: byte
+  id_void_reason: long
+  void_text: string
+psp_tips..:
+  Id: long
+  Id_pbill: long
+  amount: float
+  id_pbill_payments: long
+sold_articles..:
+  Id: long
+  id_pbill: long
+  id_order_item: long
+  quantity: int
+  parts_id: long
+  sa_coef: double
+  split_id: long
+sold_articles_wm..:
+  Id: long
+  id_order_item: long
+  id_pbill: long
+  quantity: int
+  sa_coef: double
+stock_doc..:
+  Id: long
+  id_orders: long
+  id_pbill: long
+  id_stock_invoice: long
+  id_stock_adjustment: long
+  id_stock_cost_correction: long
+stock_pbill_queue..:
+  Id: long
+  Id_pbill: long
+  pdatetime: string
+`

--- a/benchmarks/benchPBill_test.go
+++ b/benchmarks/benchPBill_test.go
@@ -13,495 +13,146 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/untillpro/dynobuffers"
 )
 
-var pbillYaml string = `
-Id: long
-Id_bill: long
-Id_untill_users: long
-number: int
-failurednumber: int
-suffix: string
-pdatetime: string
-id_sales_area: long
-pcname: string
-service_charge: double
-real_datetime: string
-tips: float
-id_clients: long
-pbill_index: int
-split_parts: double
-id_real_untill_user: long
-reopen_type: byte
-external_id: string
-covers: int
-hht: string
-super_dx: long
-c_tips: float
-id_currency: long
-bill:
-  Id: long
-  Tableno: int
-  Id_untill_users: long
-  Table_part: string
-  id_courses: long
-  id_clients: long
-  name: string
-  Proforma: byte
-  modified: string
-  open_datetime: string
-  close_datetime: string
-  number: int
-  failurednumber: int
-  suffix: string
-  pbill_number: int
-  pbill_failurednumber: int
-  pbill_suffix: string
-  hc_foliosequence: int
-  hc_folionumber: string
-  tip: float
-  qty_persons: int
-  isdirty: byte
-  reservationid: string
-  id_alter_user: long
-  service_charge: double
-  number_of_covers: int
-  id_user_proforma: long
-  bill_type: byte
-  locker: int
-  id_time_article: long
-  timer_start: string
-  timer_stop: string
-  isactive: byte
-  table_name: string
-  group_vat_level: byte
-  comments: string
-  id_cardprice: long
-  discount: double
-  discount_value: float
-  id_discount_reasons: long
-  hc_roomnumber: string
-  ignore_auto_sc: byte
-  extra_fields..: byte
-  id_bo_service_charge: long
-  free_comments: string
-  id_t2o_groups: long
-  service_tax: float
-  sc_plan..: byte
-  client_phone: string
-  age: string
-  description..: byte
-  sdescription: string
-  vars..: byte
-  take_away: int
-  fiscal_number: int
-  fiscal_failurednumber: int
-  fiscal_suffix: string
-  id_order_type: long
-  not_paid: float
-  total: float
-bill_reprints..:
-  Id: long
-  Id_pbill: long
-  datetime: string
-  id_untill_users: long
-bill_split_rest..:
-  Id: long
-  id_bill: long
-  is_active: byte
-  split_data..: byte
-  datetime: string
-  id_pbill: long
-complete_meal..:
-  Id: long
-  id_pbill: long
-  id_untill_users: long
-  cm_datetime: string
-  cm_pcname: string
-  cm_quantity: int
-  cm_price: float
-neg_pbill..:
-  Id: long
-  Id_pbill: long
-  R_type: byte
-  pdatetime: string
-  id_pbill_close: long
-open_discounts..:
-  Id: long
-  Id_pbill: long
-  amount: float
-  vat_percent: float
-  vat: double
-pbill_balance..:
-  Id: long
-  id_pbill: long
-  id_clients: long
-  id_accounts: long
-  pre_balance: float
-  pre_balance_common: float
-pbill_cleancash_info..:
-  Id: long
-  id_pbill: long
-  clean_cash_trnumber: long
-  clean_cash_signature: string
-  manufacturing_code: string
-  control_timestamp: string
-  ticket_counter: string
-  vsc_id: string
-  plu_data_hash: string
-  id_bill: long
-  ccdatetime: string
-  kind: byte
-  production_nr: string
-  extra1: string
-  extra2: string
-pbill_email..:
-  Id: long
-  id_pbill: long
-  pemail_email: string
-  pemail_body..: byte
-  pemail_dt: string
-  pemail_state: byte
-pbill_item..:
-  Id: long
-  Id_pbill: long
-  Id_untill_users: long
-  Tableno: int
-  Rowbeg: byte
-  Kind: byte
-  Quantity: int
-  id_articles: long
-  Price: float
-  text: string
-  id_prices: long
-  with_without: int
-  id_courses: long
-  pdatetime: string
-  purchase_price: float
-  vat_sign: string
-  vat: double
-  id_menu: long
-  menu_quantity: int
-  original_price: float
-  id_discount_reasons: long
-  discount_type: int
-  chair_number: int
-  separated: byte
-  negative: byte
-  vat_percent: float
-  chair_name: string
-  id_option_article: long
-  start_delay_minutes: int
-  pua: byte
-  no_price: byte
-  orig_pbill_id: long
-  parts_id: long
-  full_paid: byte
-  weight: float
-  splitted_coef: double
-  split_id: long
-  free_comments: string
-  id_smartcards: long
-  has_allergens: byte
-  id_article_options: long
-  order_item_allergens..:
-    Id: long
-    id_order_item: long
-    id_menu_item: long
-    id_allergens: long
-    text: string
-    id_pbill_item: long
-  order_item_extra..:
-    Id: long
-    id_order_item: long
-    id_menu_item: long
-    id_pbill_item: long
-    id_article_barcodes: long
-  order_item_sizes..:
-    Id: long
-    id_order_item: long
-    id_menu_item: long
-    id_pbill_item: long
-    id_articles: long
-    price: float
-    original_price: float
-    vat: double
-    id_size_modifier_item: long
-  pbill_hash..:
-    Id: long
-    Id_pbill_item: long
-    Id_untill_users: long
-  pbill_item_bookp..:
-    Id: long
-    id_pbill_item: long
-    id_bookkeeping_turnover: long
-    id_bookkeeping_vat: long
-pbill_item_refund..:
-  Id: long
-  Id_pbill: long
-  Id_untill_users: long
-  Tableno: int
-  Rowbeg: byte
-  Kind: byte
-  Quantity: int
-  id_articles: long
-  id_department: long
-  id_food_group: long
-  id_category: long
-  Price: float
-  text: string
-  id_prices: long
-  with_without: int
-  id_courses: long
-  pdatetime: string
-  purchase_price: float
-  vat_sign: string
-  vat: double
-  id_menu: long
-  menu_quantity: int
-  ref_type: byte
-pbill_payments..:
-  Id: long
-  Id_pbill: long
-  Id_payments: long
-  Price: float
-  customer_amount: float
-  c_price: float
-  c_customer_amount: float
-  vat: float
-  id_driver_discount: long
-  accounts_payments..:
-    Id: long
-    datetime: string
-    Id_clients: long
-    Id_untill_users: long
-    tableno: int
-    tablepart: string
-    number: int
-    suffix: string
-    name: string
-    tr_datetime: string
-    bill_number: string
-    parts_count: byte
-    part_index: byte
-    discount: double
-    id_sales_area: long
-    total: float
-    account_type: byte
-    payer_name: string
-    id_pbill_payments: long
-  account_payment_data..:
-    Id: long
-    id_pbill_payments: long
-    account_type: byte
-  payments_hash..:
-    Id: long
-    Id_payments: long
-    Id_untill_users: long
-  pbill_card_payments_info..:
-    Id: long
-    Id_pbill_payments: long
-    masked_pan: string
-    pan: string
-    expire: string
-    auth_number: string
-    acquier_code: string
-    field1: string
-    field2: string
-    field3: string
-    field4: string
-    field5: string
-    track2data: string
-    loyaltyamount: long
-    controlno: string
-    chargetype: int
-    cardname: string
-    cardnoentertype: int
-    terminalid: string
-    aid: string
-    tvr: string
-    tsi: string
-    account_type: string
-    customer_receipt: string
-    merchant_receipt: string
-    tip_approvement: byte
-    prepaid_pan: string
-    misc_data..: byte
-    field6: string
-    field7: string
-    field8: string
-    field9: string
-    field10: string
-    merchant_id: string
-    cashback_amount: long
-    field11: string
-    field12: string
-    field13: string
-    field14: string
-    field15: string
-  pbill_payer..:
-    Id: long
-    id_pbill_payments: long
-    payer_name: string
-  pbill_payments_bookp..:
-    Id: long
-    id_pbill_payments: long
-    id_bookkeeping: long
-  pbill_zapper_payments_info..:
-    Id: long
-    Id_pbill_payments: long
-    Id_zapper_proformas: long
-    zapper_id: string
-    misc_data..: byte
-  psp_tips..:
-    Id: long
-    Id_pbill: long
-    amount: float
-    id_pbill_payments: long
-  smartcards_turnover..:
-    Id: long
-    datetime: string
-    Id_smartcards: long
-    Id_untill_users: long
-    kind: byte
-    amount: float
-    p_amount: float
-    id_pbill_payments: long
-    id_payments: long
-    is_initial_value: byte
-    card_data..: byte
-    deposit_number: int
-    deposit_suffix: string
-    pcname: string
-    new_balance: float
-  voucher_payments..:
-    Id: long
-    id_vouchers: long
-    id_pbill_payments: long
-    used_dt: string
-  voucher_pbill_payments..:
-    Id: long
-    id_voucher_pbill: long
-    price: float
-    id_vouchers: long
-    id_payments: long
-    id_pbill_payments: long
-pbill_return..:
-  Id: long
-  id_pbill: long
-  ref_type: byte
-  id_void_reason: long
-  void_text: string
-psp_tips..:
-  Id: long
-  Id_pbill: long
-  amount: float
-  id_pbill_payments: long
-sold_articles..:
-  Id: long
-  id_pbill: long
-  id_order_item: long
-  quantity: int
-  parts_id: long
-  sa_coef: double
-  split_id: long
-sold_articles_wm..:
-  Id: long
-  id_order_item: long
-  id_pbill: long
-  quantity: int
-  sa_coef: double
-stock_doc..:
-  Id: long
-  id_orders: long
-  id_pbill: long
-  id_stock_invoice: long
-  id_stock_adjustment: long
-  id_stock_cost_correction: long
-stock_pbill_queue..:
-  Id: long
-  Id_pbill: long
-  pdatetime: string
-`
-
-func BenchmarkPBillSet(b *testing.B) {
+func BenchmarkPBill_ApplyMap(b *testing.B) {
 	s, err := dynobuffers.YamlToScheme(pbillYaml)
-	if err != nil {
-		b.Fatal(err)
-	}
-
+	require.Nil(b, err)
 	bb := dynobuffers.NewBuffer(s)
-
 	fillBuffer(bb)
-
-	jsonBytes := []byte(bb.ToJSON())
-
+	jsonBytes := bb.ToJSON()
 	dest := map[string]interface{}{}
-	err = json.Unmarshal(jsonBytes, &dest)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, json.Unmarshal(jsonBytes, &dest))
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pb := dynobuffers.NewBuffer(s)
-
-		err = pb.ApplyMap(dest)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			pb := dynobuffers.NewBuffer(s)
+			if err = pb.ApplyMap(dest); err != nil {
+				b.Fatal(err)
+			}
+			if _, err = pb.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			pb.Release()
 		}
-		_, _ = pb.ToBytes()
-
-		pb.Release()
-	}
+	})
 }
 
-func BenchmarkPBillAppend(b *testing.B) {
+func BenchmarkPBill_ApplyMap_Append(b *testing.B) {
 	s, err := dynobuffers.YamlToScheme(pbillYaml)
-	if err != nil {
-		b.Fatal(err)
-	}
-
+	require.Nil(b, err)
 	pb := dynobuffers.NewBuffer(s)
-
 	fillBuffer(pb)
-
 	jsonBytes := []byte(pb.ToJSON())
 	pb = dynobuffers.NewBuffer(s)
-	dest := map[string]interface{}{}
-	err = json.Unmarshal(jsonBytes, &dest)
-	if err != nil {
-		b.Fatal(err)
-	}
+
 	bytes, err := pb.ApplyJSONAndToBytes(jsonBytes)
+	require.Nil(b, err)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pb = dynobuffers.ReadBuffer(bytes, s)
-		err = pb.ApplyMap(dest)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		dest := map[string]interface{}{}
+		require.Nil(b, json.Unmarshal(jsonBytes, &dest))
+		for p.Next() {
+			pb := dynobuffers.ReadBuffer(bytes, s)
+			if err = pb.ApplyMap(dest); err != nil {
+				b.Fatal(err)
+			}
+			if _, err = pb.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			pb.Release()
 		}
-		_, _ = pb.ToBytes()
-		pb = dynobuffers.ReadBuffer(bytes, s)
-		pb.Release()
-	}
+	})
 }
 
-func BenchmarkPBillItemReadByIndex(b *testing.B) {
+func BenchmarkPBill_ItemRead_ByIndex(b *testing.B) {
 	s, err := dynobuffers.YamlToScheme(pbillYaml)
-	if err != nil {
-		b.Fatal(err)
+	require.Nil(b, err)
+	pb := dynobuffers.NewBuffer(s)
+	fillBuffer(pb)
+	bytes, err := pb.ToBytes()
+	require.Nil(b, err)
+
+	pb = dynobuffers.ReadBuffer(bytes, s)
+	pbillItem := pb.GetByIndex("pbill_item", 0).(*dynobuffers.Buffer)
+	pbillItems := []*dynobuffers.Buffer{}
+	for i := 0; i < 9; i++ {
+		pbillItems = append(pbillItems, pbillItem)
 	}
+	pb.Append("pbill_item", pbillItems)
+	bytes, err = pb.ToBytes()
+	require.Nil(b, err)
+	pb = dynobuffers.ReadBuffer(bytes, s)
+	assert.Equal(b, 10, pb.Get("pbill_item").(*dynobuffers.ObjectArray).Len)
+	sum := float32(0)
+
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			pb := dynobuffers.ReadBuffer(bytes, s)
+			for i := 0; i < 10; i++ {
+				pbillItem := pb.GetByIndex("pbill_item", i).(*dynobuffers.Buffer)
+				s, _ := pbillItem.GetFloat("price")
+				sum += s
+				pbillItem.Release()
+			}
+			pb.Release()
+		}
+	})
+	_ = sum
+}
+
+func BenchmarkPBill_ItemRead_Iter(b *testing.B) {
+	s, err := dynobuffers.YamlToScheme(pbillYaml)
+	require.Nil(b, err)
+	pb := dynobuffers.NewBuffer(s)
+	fillBuffer(pb)
+	bytes, err := pb.ToBytes()
+	require.Nil(b, err)
+	pb = dynobuffers.ReadBuffer(bytes, s)
+	pbillItem := pb.GetByIndex("pbill_item", 0).(*dynobuffers.Buffer)
+	pbillItems := []*dynobuffers.Buffer{}
+	for i := 0; i < 9; i++ {
+		pbillItems = append(pbillItems, pbillItem)
+	}
+	pb.Append("pbill_item", pbillItems)
+	bytes, err = pb.ToBytes()
+	require.Nil(b, err)
+
+	pb = dynobuffers.ReadBuffer(bytes, s)
+	assert.Equal(b, 10, pb.Get("pbill_item").(*dynobuffers.ObjectArray).Len)
+
+	sum := float32(0)
+
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			pb := dynobuffers.ReadBuffer(bytes, s)
+			pbillItems := pb.Get("pbill_item").(*dynobuffers.ObjectArray)
+			for pbillItems.Next() {
+				s, _ := pbillItems.Buffer.GetFloat("price")
+				sum += s
+			}
+			pbillItems.Release()
+			pb.Release()
+		}
+	})
+	_ = sum
+}
+
+func BenchmarkPBillItem_Read_NoAlloc(b *testing.B) {
+	s, err := dynobuffers.YamlToScheme(pbillYaml)
+	require.Nil(b, err)
 
 	pb := dynobuffers.NewBuffer(s)
 
 	fillBuffer(pb)
 	bytes, err := pb.ToBytes()
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
 
 	pb = dynobuffers.ReadBuffer(bytes, s)
 	pbillItem := pb.GetByIndex("pbill_item", 0).(*dynobuffers.Buffer)
@@ -512,9 +163,7 @@ func BenchmarkPBillItemReadByIndex(b *testing.B) {
 	pb.Append("pbill_item", pbillItems)
 
 	bytes, err = pb.ToBytes()
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
 
 	pb = dynobuffers.ReadBuffer(bytes, s)
 	assert.Equal(b, 10, pb.Get("pbill_item").(*dynobuffers.ObjectArray).Len)
@@ -522,133 +171,43 @@ func BenchmarkPBillItemReadByIndex(b *testing.B) {
 	sum := float32(0)
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pb = dynobuffers.ReadBuffer(bytes, s)
-		for i := 0; i < 10; i++ {
-			pbillItem := pb.GetByIndex("pbill_item", i).(*dynobuffers.Buffer)
-			s, _ := pbillItem.GetFloat("price")
-			sum += s
-			pbillItem.Release()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			pb := dynobuffers.ReadBuffer(bytes, s)
+			arr := pb.Get("pbill_item").(*dynobuffers.ObjectArray)
+			for arr.Next() {
+				s, _ := arr.Buffer.GetFloat("price")
+				sum += s
+			}
+			arr.Release()
+			pb.Release()
 		}
-		pb.Release()
-	}
+	})
 	_ = sum
 }
 
-func BenchmarkPBillItemReadIter(b *testing.B) {
+func BenchmarkPbill_Json_ReadWrite(b *testing.B) {
 	s, err := dynobuffers.YamlToScheme(pbillYaml)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	pb := dynobuffers.NewBuffer(s)
-
-	fillBuffer(pb)
-	bytes, err := pb.ToBytes()
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	pb = dynobuffers.ReadBuffer(bytes, s)
-	pbillItem := pb.GetByIndex("pbill_item", 0).(*dynobuffers.Buffer)
-	pbillItems := []*dynobuffers.Buffer{}
-	for i := 0; i < 9; i++ {
-		pbillItems = append(pbillItems, pbillItem)
-	}
-	pb.Append("pbill_item", pbillItems)
-
-	bytes, err = pb.ToBytes()
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	pb = dynobuffers.ReadBuffer(bytes, s)
-	assert.Equal(b, 10, pb.Get("pbill_item").(*dynobuffers.ObjectArray).Len)
-
-	sum := float32(0)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pb = dynobuffers.ReadBuffer(bytes, s)
-		pbillItems := pb.Get("pbill_item").(*dynobuffers.ObjectArray)
-		// pbillItems.GetDoubles()
-		for pbillItems.Next() {
-			s, _ := pbillItems.Buffer.GetFloat("price")
-			sum += s
-		}
-
-		pb.Release()
-	}
-	_ = sum
-}
-
-func BenchmarkPBillItemReadNoAlloc(b *testing.B) {
-	s, err := dynobuffers.YamlToScheme(pbillYaml)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	pb := dynobuffers.NewBuffer(s)
-
-	fillBuffer(pb)
-	bytes, err := pb.ToBytes()
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	pb = dynobuffers.ReadBuffer(bytes, s)
-	pbillItem := pb.GetByIndex("pbill_item", 0).(*dynobuffers.Buffer)
-	pbillItems := []*dynobuffers.Buffer{}
-	for i := 0; i < 9; i++ {
-		pbillItems = append(pbillItems, pbillItem)
-	}
-	pb.Append("pbill_item", pbillItems)
-
-	bytes, err = pb.ToBytes()
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	pb = dynobuffers.ReadBuffer(bytes, s)
-	assert.Equal(b, 10, pb.Get("pbill_item").(*dynobuffers.ObjectArray).Len)
-
-	sum := float32(0)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pb = dynobuffers.ReadBuffer(bytes, s)
-		arr := pb.Get("pbill_item").(*dynobuffers.ObjectArray)
-		for arr.Next() {
-			s, _ := arr.Buffer.GetFloat("price")
-			sum += s
-		}
-		pb.Release()
-	}
-	_ = sum
-}
-
-func BenchmarkPbillJson(b *testing.B) {
-	s, err := dynobuffers.YamlToScheme(pbillYaml)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
 
 	pb := dynobuffers.NewBuffer(s)
 
 	fillBuffer(pb)
 
-	jsonBytes := []byte(pb.ToJSON())
-	dest := map[string]interface{}{}
+	jsonBytes := pb.ToJSON()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err = json.Unmarshal(jsonBytes, &dest)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		dest := map[string]interface{}{}
+		for p.Next() {
+			if err = json.Unmarshal(jsonBytes, &dest); err != nil {
+				b.Fatal(err)
+			}
+			if _, err = json.Marshal(dest); err != nil {
+				b.Fatal(err)
+			}
 		}
-		_, _ = json.Marshal(dest)
-		dest = map[string]interface{}{}
-	}
+	})
 }
 
 func fillBuffer(b *dynobuffers.Buffer) {

--- a/benchmarks/benchReadWrite_test.go
+++ b/benchmarks/benchReadWrite_test.go
@@ -9,10 +9,10 @@ package benchmarks
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/untillpro/dynobuffers"
 
 	flatbuffers "github.com/google/flatbuffers/go"
@@ -26,21 +26,24 @@ func BenchmarkWriteDynoBuffersSimpleTyped(b *testing.B) {
 	bf.Set("price", float32(0.123))
 	bf.Set("quantity", int32(42))
 	bytes, err := bf.ToBytes()
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
 
 	b.ResetTimer()
-	sum := float32(0)
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.ReadBuffer(bytes, s)
-		price, _ := bf.GetFloat("price")
-		quantity, _ := bf.GetInt("quantity")
-		sum += price * float32(quantity)
-		bf.Set("quantity", int32(3))
-		_, _ = bf.ToBytes()
-		bf.Release()
-	}
+	b.RunParallel(func(p *testing.PB) {
+		sum := float32(0)
+		for p.Next() {
+			bf := dynobuffers.ReadBuffer(bytes, s)
+			price, _ := bf.GetFloat("price")
+			quantity, _ := bf.GetInt("quantity")
+			sum += price * float32(quantity)
+			bf.Set("quantity", int32(3))
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+
+			bf.Release()
+		}
+	})
 }
 
 func BenchmarkWriteDynoBuffersSimpleTypedReadWriteString(b *testing.B) {
@@ -49,20 +52,25 @@ func BenchmarkWriteDynoBuffersSimpleTypedReadWriteString(b *testing.B) {
 	bf.Set("name", "cola")
 	bf.Set("price", float32(0.123))
 	bf.Set("quantity", int32(42))
-	bytes, _ := bf.ToBytes()
+	bytes, err := bf.ToBytes()
+	require.Nil(b, err)
 
 	b.ResetTimer()
-	sum := float32(0)
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.ReadBuffer(bytes, s)
-		price, _ := bf.GetFloat("price")
-		quantity, _ := bf.GetInt("quantity")
-		_, _ = bf.GetString("name")
-		sum += price * float32(quantity)
-		bf.Set("name", "new")
-		_, _ = bf.ToBytes()
-		bf.Release()
-	}
+	b.RunParallel(func(p *testing.PB) {
+		sum := float32(0)
+		for p.Next() {
+			bf := dynobuffers.ReadBuffer(bytes, s)
+			price, _ := bf.GetFloat("price")
+			quantity, _ := bf.GetInt("quantity")
+			_, _ = bf.GetString("name")
+			sum += price * float32(quantity)
+			bf.Set("name", "new")
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			bf.Release()
+		}
+	})
 }
 
 func BenchmarkWriteDynoBuffersSimpleUntyped(b *testing.B) {
@@ -71,19 +79,24 @@ func BenchmarkWriteDynoBuffersSimpleUntyped(b *testing.B) {
 	bf.Set("name", "cola")
 	bf.Set("price", float32(0.123))
 	bf.Set("quantity", int32(42))
-	bytes, _ := bf.ToBytes()
+	bytes, err := bf.ToBytes()
+	require.Nil(b, err)
 
 	b.ResetTimer()
-	sum := float32(0)
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.ReadBuffer(bytes, s)
-		price := bf.Get("price").(float32)
-		quantity := bf.Get("quantity").(int32)
-		sum += price * float32(quantity)
-		bf.Set("quantity", int32(3))
-		_, _ = bf.ToBytes()
-		bf.Release()
-	}
+	b.RunParallel(func(p *testing.PB) {
+		sum := float32(0)
+		for p.Next() {
+			bf := dynobuffers.ReadBuffer(bytes, s)
+			price := bf.Get("price").(float32) // 1 alloc here
+			quantity := bf.Get("quantity").(int32)
+			sum += price * float32(quantity)
+			bf.Set("quantity", int32(3))
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			bf.Release()
+		}
+	})
 }
 
 func BenchmarkWriteFlatBuffersSimple(b *testing.B) {
@@ -98,51 +111,50 @@ func BenchmarkWriteFlatBuffersSimple(b *testing.B) {
 	bytes := bl.FinishedBytes()
 
 	b.ResetTimer()
-	var sum float64
-	for i := 0; i < b.N; i++ {
-		saleNew := GetRootAsSale(bytes, 0)
-		sum += float64(saleNew.Price()) * float64(saleNew.Quantity())
+	b.RunParallel(func(p *testing.PB) {
 		bl := flatbuffers.NewBuilder(0)
-		colaName := bl.CreateString("cola")
-		SaleStart(bl)
-		SaleAddName(bl, colaName)
-		SaleAddPrice(bl, 0.123)
-		SaleAddQuantity(bl, int32(1))
-		sale := SaleEnd(bl)
-		bl.Finish(sale)
-		_ = bl.FinishedBytes()
-	}
+		sum := float32(0)
+		for p.Next() {
+			saleNew := GetRootAsSale(bytes, 0)
+			sum += saleNew.Price() * float32(saleNew.Quantity())
+			colaName := bl.CreateString("cola")
+			SaleStart(bl)
+			SaleAddName(bl, colaName)
+			SaleAddPrice(bl, 0.123)
+			SaleAddQuantity(bl, int32(1))
+			sale := SaleEnd(bl)
+			bl.Finish(sale)
+			_ = bl.FinishedBytes()
+			bl.Reset()
+		}
+	})
 }
 
 func BenchmarkWriteJsonSimple(b *testing.B) {
-	var data map[string]interface{}
-	data = map[string]interface{}{
+	data := map[string]interface{}{
 		"name":     "cola",
 		"price":    0.123,
 		"quantity": int32(1),
 	}
 	bytes, err := json.Marshal(data)
-	if err != nil {
-		fmt.Println(err)
-	}
+	require.Nil(b, err)
 
 	b.ResetTimer()
-
-	var sum float64
-	for i := 0; i < b.N; i++ {
-		data = map[string]interface{}{}
-		err = json.Unmarshal(bytes, &data)
-		if err != nil {
-			fmt.Println(err)
+	b.RunParallel(func(p *testing.PB) {
+		sum := float32(0)
+		for p.Next() {
+			data := map[string]interface{}{}
+			if err = json.Unmarshal(bytes, &data); err != nil {
+				b.Fatal(err)
+			}
+			price := float32(data["price"].(float64))
+			sum += price * float32(data["quantity"].(float64))
+			data["quantity"] = 123
+			if _, err := json.Marshal(data); err != nil {
+				b.Fatal(err)
+			}
 		}
-		price := float64(data["price"].(float64))
-		sum += price * data["quantity"].(float64)
-		data["quantity"] = 123
-		_, err := json.Marshal(data)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
+	})
 }
 
 func BenchmarkWriteLinkedInAvroSimple(b *testing.B) {
@@ -156,54 +168,56 @@ func BenchmarkWriteLinkedInAvroSimple(b *testing.B) {
 			{"name": "quantity", "type": "int", "default": 0}
 		]}
 	`)
-	if err != nil {
-		fmt.Println(err)
-	}
+	require.Nil(b, err)
 	data := map[string]interface{}{
 		"name":     string("cola"),
 		"price":    goavro.Union("float", float32(0.123)),
 		"quantity": 1,
 	}
 	bytes, err := codec.BinaryFromNative(nil, data)
-	if err != nil {
-		fmt.Println(err)
-	}
+	require.Nil(b, err)
 
 	b.ResetTimer()
-
-	var sum float64
-	for i := 0; i < b.N; i++ {
-		native, _, err := codec.NativeFromBinary(bytes)
-		if err != nil {
-			fmt.Println(err)
+	b.RunParallel(func(p *testing.PB) {
+		sum := float32(0)
+		for p.Next() {
+			native, _, err := codec.NativeFromBinary(bytes)
+			if err != nil {
+				b.Fatal(err)
+			}
+			decoded := native.(map[string]interface{})
+			price := decoded["price"].(map[string]interface{})["float"].(float32)
+			sum += price * float32(decoded["quantity"].(int32))
+			decoded["quantity"] = 123
+			if _, err = codec.BinaryFromNative(nil, decoded); err != nil {
+				b.Fatal(err)
+			}
 		}
-		decoded := native.(map[string]interface{})
-		price := float64(decoded["price"].(map[string]interface{})["float"].(float32))
-		sum += price * float64(decoded["quantity"].(int32))
-		decoded["quantity"] = 123
-		_, err = codec.BinaryFromNative(nil, decoded)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
+	})
 }
 
 func BenchmarkWriteDynoBuffersArticleReadFewFieldsTyped(b *testing.B) {
 	s := getArticleSchemeDynoBuffer()
 	bf := dynobuffers.NewBuffer(s)
 	fillArticleDynoBuffer(bf)
-	bytes, _ := bf.ToBytes()
+	bytes, err := bf.ToBytes()
+	require.Nil(b, err)
+
 	b.ResetTimer()
-	sum := float64(0)
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.ReadBuffer(bytes, s)
-		q, _ := bf.GetInt("quantity")
-		price, _ := bf.GetFloat("purchase_price")
-		sum += float64(float32(q) * price)
-		bf.Set("qauntity", int32(123))
-		_, _ = bf.ToBytes()
-		bf.Release()
-	}
+	b.RunParallel(func(p *testing.PB) {
+		sum := float64(0)
+		for p.Next() {
+			bf := dynobuffers.ReadBuffer(bytes, s)
+			q, _ := bf.GetInt("quantity")
+			price, _ := bf.GetFloat("purchase_price")
+			sum += float64(float32(q) * price)
+			bf.Set("qauntity", int32(123))
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(b, err)
+			}
+			bf.Release()
+		}
+	})
 }
 func BenchmarkWriteFlatBuffersArticleReadFewFields(b *testing.B) {
 	bl := flatbuffers.NewBuilder(0)
@@ -212,77 +226,78 @@ func BenchmarkWriteFlatBuffersArticleReadFewFields(b *testing.B) {
 	bytes := bl.FinishedBytes()
 
 	b.ResetTimer()
-	sum := float64(0)
-	for i := 0; i < b.N; i++ {
-		ar := GetRootAsArticle(bytes, 0)
-		sum += float64(ar.PurchasePrice()) * float64(ar.Quantity())
-		bl := flatbuffers.NewBuilder(0)
-		a := fillArticleFlatBuffers(bl)
-		bl.Finish(a)
-		_ = bl.FinishedBytes()
-	}
+	b.RunParallel(func(p *testing.PB) {
+		sum := float32(0)
+		for p.Next() {
+			ar := GetRootAsArticle(bytes, 0)
+			sum += ar.PurchasePrice() * float32(ar.Quantity())
+			bl := flatbuffers.NewBuilder(0)
+			a := fillArticleFlatBuffers(bl)
+			bl.Finish(a)
+			_ = bl.FinishedBytes()
+		}
+	})
 }
 
 func BenchmarkWriteJsonArticleReadFewFields(b *testing.B) {
 	s := getArticleSchemeDynoBuffer()
 	bf := dynobuffers.NewBuffer(s)
 	fillArticleDynoBuffer(bf)
-	jsonStr := bf.ToJSON()
-	dest := map[string]interface{}{}
+	jsonBytes := bf.ToJSON()
+
 	b.ResetTimer()
-	sum := float64(0)
-	for i := 0; i < b.N; i++ {
-		json.Unmarshal([]byte(jsonStr), &dest)
-		_ = dest["id_courses"]
-		q := dest["quantity"].(float64)
-		price := dest["purchase_price"].(float64)
-		sum += q * price
-		dest["quantity"] = 123
-		_, err := json.Marshal(dest)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		sum := float64(0)
+		for p.Next() {
+			dest := map[string]interface{}{}
+			if err := json.Unmarshal(jsonBytes, &dest); err != nil {
+				b.Fatal(err)
+			}
+			_ = dest["id_courses"]
+			q := dest["quantity"].(float64)
+			price := dest["purchase_price"].(float64)
+			sum += q * price
+			dest["quantity"] = 123
+			if _, err := json.Marshal(dest); err != nil {
+				b.Fatal(err)
+			}
 		}
-	}
+	})
 }
 
 func BenchmarkWriteLinkedInAvroArticleReadFewFields(b *testing.B) {
 	schemaStr, err := ioutil.ReadFile("article.avsc")
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
+
 	codec, err := goavro.NewCodec(string(schemaStr))
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
+
 	articleData, err := ioutil.ReadFile("articleData.json")
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
+
 	native, _, err := codec.NativeFromTextual(articleData)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
+
 	bytes, err := codec.BinaryFromNative(nil, native)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.Nil(b, err)
 
 	b.ResetTimer()
-	sum := float64(0)
-	for i := 0; i < b.N; i++ {
-		native, _, err = codec.NativeFromBinary(bytes)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		sum := float64(0)
+		for p.Next() {
+			native, _, err := codec.NativeFromBinary(bytes)
+			if err != nil {
+				b.Fatal(err)
+			}
+			decoded := native.(map[string]interface{})
+			price := float64(decoded["purchase_price"].(float32))
+			sum += price * float64(decoded["quantity"].(int32))
+			decoded["quantity"] = 123
+			if _, err = codec.BinaryFromNative(nil, decoded); err != nil {
+				b.Fatal(err)
+			}
 		}
-		decoded := native.(map[string]interface{})
-		price := float64(decoded["purchase_price"].(float32))
-		sum += price * float64(decoded["quantity"].(int32))
-		decoded["quantity"] = 123
-		_, err = codec.BinaryFromNative(nil, decoded)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
+	})
 
 }
 
@@ -293,547 +308,558 @@ func BenchmarkWriteFlatBuffersArticleReadAllFields(b *testing.B) {
 	bytes := bl.FinishedBytes()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		a := GetRootAsArticle(bytes, 0)
-		a.Id()
-		a.ArticleNumber()
-		a.Name()
-		a.InternalName()
-		a.ArticleManual()
-		a.ArticleHash()
-		a.IdCourses()
-		a.IdDepartament()
-		a.PcBitmap()
-		a.PcColor()
-		a.PcText()
-		a.PcFontName()
-		a.PcFontSize()
-		a.PcFontAttr()
-		a.PcFontColor()
-		a.RmText()
-		a.RmFontSize()
-		a.IdPacking()
-		a.IdCommission()
-		a.IdPromotions()
-		a.Savepoints()
-		a.Quantity()
-		a.Hideonhold()
-		a.Barcode()
-		a.TimeActive()
-		a.Aftermin()
-		a.Periodmin()
-		a.Roundmin()
-		a.IdCurrency()
-		a.ControlActive()
-		a.ControlTime()
-		a.PluNumberVanduijnen()
-		a.Sequence()
-		a.RmSequence()
-		a.PurchasePrice()
-		a.IdVdGroup()
-		a.Menu()
-		a.Sensitive()
-		a.SensitiveOption()
-		a.DailyStock()
-		a.Info()
-		a.WarningLevel()
-		a.FreeAfterPay()
-		a.IdFoodGroup()
-		a.ArticleType()
-		a.IdInventoryItem()
-		a.IdRecipe()
-		a.IdUnitySales()
-		a.CanSavepoints()
-		a.ShowInKitchenScreen()
-		a.DecreaseSavepoints()
-		a.HhtColor()
-		a.HhtFontName()
-		a.HhtFontSize()
-		a.HhtFontAttr()
-		a.HhtFontColor()
-		a.Tip()
-		a.IdBecoGroup()
-		a.IdBecoLocation()
-		a.BcStandardDosage()
-		a.BcAlternativeDosage()
-		a.BcDisablebalance()
-		a.BcUseLocations()
-		a.TimeRate()
-		a.IdFreeOption()
-		a.PartyArticle()
-		a.IdPuaGroups()
-		a.Promo()
-		a.OneHandLimit()
-		a.ConsolidateQuantity()
-		a.ConsolidateAliasName()
-		a.HqId()
-		a.IsActive()
-		a.IsActiveModified()
-		a.IsActiveModifier()
-		a.RentPriceType()
-		a.IdRentalGroup()
-		a.ConditionCheckInOrder()
-		a.WeightRequired()
-		a.DailyNumeric1()
-		a.DailyNumeric2()
-		a.PrepMin()
-		a.IdArticleKsp()
-		a.WarnMin()
-		a.EmptyArticle()
-		a.BcDebitcredit()
-		a.PrepSec()
-		a.IdSuppliers()
-		a.MainPrice()
-		a.OmanText()
-		a.IdAgeGroups()
-		a.PosDisabled()
-		a.MlName()
-		a.MlKsName()
-		a.AltArticles()
-		a.NeedPrep()
-		a.AutoOnhold()
-		a.IdKsWf()
-		a.KsWfType()
-		a.AskCourse()
-		a.AllowOrderItems()
-		a.MustCombined()
-		a.BlockDiscount()
-		a.HasDefaultOptions()
-		a.HhtDefaultSetting()
-		a.OmanDefaultSetting()
-		a.IdRentPeriods()
-		a.DelaySeparateMins()
-		a.IdKsc()
-		a.MlPcText()
-		a.MlRmText()
-		a.MlOmanText()
-		a.PosArticleType()
-		a.SingleFreeOption()
-		a.KsSingleItem()
-		a.Allergen()
-		a.AutoResetcourse()
-		a.BlockTransfer()
-		a.IdSizeModifier()
-		bl := flatbuffers.NewBuilder(0)
-		ar := fillArticleFlatBuffers(bl)
-		bl.Finish(ar)
-		_ = bl.FinishedBytes()
-
-	}
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			a := GetRootAsArticle(bytes, 0)
+			a.Id()
+			a.ArticleNumber()
+			a.Name()
+			a.InternalName()
+			a.ArticleManual()
+			a.ArticleHash()
+			a.IdCourses()
+			a.IdDepartament()
+			a.PcBitmap()
+			a.PcColor()
+			a.PcText()
+			a.PcFontName()
+			a.PcFontSize()
+			a.PcFontAttr()
+			a.PcFontColor()
+			a.RmText()
+			a.RmFontSize()
+			a.IdPacking()
+			a.IdCommission()
+			a.IdPromotions()
+			a.Savepoints()
+			a.Quantity()
+			a.Hideonhold()
+			a.Barcode()
+			a.TimeActive()
+			a.Aftermin()
+			a.Periodmin()
+			a.Roundmin()
+			a.IdCurrency()
+			a.ControlActive()
+			a.ControlTime()
+			a.PluNumberVanduijnen()
+			a.Sequence()
+			a.RmSequence()
+			a.PurchasePrice()
+			a.IdVdGroup()
+			a.Menu()
+			a.Sensitive()
+			a.SensitiveOption()
+			a.DailyStock()
+			a.Info()
+			a.WarningLevel()
+			a.FreeAfterPay()
+			a.IdFoodGroup()
+			a.ArticleType()
+			a.IdInventoryItem()
+			a.IdRecipe()
+			a.IdUnitySales()
+			a.CanSavepoints()
+			a.ShowInKitchenScreen()
+			a.DecreaseSavepoints()
+			a.HhtColor()
+			a.HhtFontName()
+			a.HhtFontSize()
+			a.HhtFontAttr()
+			a.HhtFontColor()
+			a.Tip()
+			a.IdBecoGroup()
+			a.IdBecoLocation()
+			a.BcStandardDosage()
+			a.BcAlternativeDosage()
+			a.BcDisablebalance()
+			a.BcUseLocations()
+			a.TimeRate()
+			a.IdFreeOption()
+			a.PartyArticle()
+			a.IdPuaGroups()
+			a.Promo()
+			a.OneHandLimit()
+			a.ConsolidateQuantity()
+			a.ConsolidateAliasName()
+			a.HqId()
+			a.IsActive()
+			a.IsActiveModified()
+			a.IsActiveModifier()
+			a.RentPriceType()
+			a.IdRentalGroup()
+			a.ConditionCheckInOrder()
+			a.WeightRequired()
+			a.DailyNumeric1()
+			a.DailyNumeric2()
+			a.PrepMin()
+			a.IdArticleKsp()
+			a.WarnMin()
+			a.EmptyArticle()
+			a.BcDebitcredit()
+			a.PrepSec()
+			a.IdSuppliers()
+			a.MainPrice()
+			a.OmanText()
+			a.IdAgeGroups()
+			a.PosDisabled()
+			a.MlName()
+			a.MlKsName()
+			a.AltArticles()
+			a.NeedPrep()
+			a.AutoOnhold()
+			a.IdKsWf()
+			a.KsWfType()
+			a.AskCourse()
+			a.AllowOrderItems()
+			a.MustCombined()
+			a.BlockDiscount()
+			a.HasDefaultOptions()
+			a.HhtDefaultSetting()
+			a.OmanDefaultSetting()
+			a.IdRentPeriods()
+			a.DelaySeparateMins()
+			a.IdKsc()
+			a.MlPcText()
+			a.MlRmText()
+			a.MlOmanText()
+			a.PosArticleType()
+			a.SingleFreeOption()
+			a.KsSingleItem()
+			a.Allergen()
+			a.AutoResetcourse()
+			a.BlockTransfer()
+			a.IdSizeModifier()
+			bl := flatbuffers.NewBuilder(0)
+			ar := fillArticleFlatBuffers(bl)
+			bl.Finish(ar)
+			_ = bl.FinishedBytes()
+		}
+	})
 }
 
 func BenchmarkWriteJsonArticleReadAllFields(b *testing.B) {
 	data, err := ioutil.ReadFile("articleData.json")
-	if err != nil {
-		b.Fatal(err)
-	}
-	jsonStr := string(data)
-	dest := map[string]interface{}{}
+	require.Nil(b, err)
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		json.Unmarshal([]byte(jsonStr), &dest)
-		_ = dest["id"]
-		_ = dest["article_number"]
-		_ = dest["name"]
-		_ = dest["internal_name"]
-		_ = dest["article_manual"]
-		_ = dest["article_hash"]
-		_ = dest["id_courses"]
-		_ = dest["id_departament"]
-		_ = dest["pc_bitmap"]
-		_ = dest["pc_color"]
-		_ = dest["pc_text"]
-		_ = dest["pc_font_name"]
-		_ = dest["pc_font_size"]
-		_ = dest["pc_font_attr"]
-		_ = dest["pc_font_color"]
-		_ = dest["rm_text"]
-		_ = dest["rm_font_size"]
-		_ = dest["id_packing"]
-		_ = dest["id_commission"]
-		_ = dest["id_promotions"]
-		_ = dest["savepoints"]
-		_ = dest["quantity"]
-		_ = dest["hideonhold"]
-		_ = dest["barcode"]
-		_ = dest["time_active"]
-		_ = dest["aftermin"]
-		_ = dest["periodmin"]
-		_ = dest["roundmin"]
-		_ = dest["id_currency"]
-		_ = dest["control_active"]
-		_ = dest["control_time"]
-		_ = dest["plu_number_vanduijnen"]
-		_ = dest["sequence"]
-		_ = dest["rm_sequence"]
-		_ = dest["purchase_price"]
-		_ = dest["id_vd_group"]
-		_ = dest["menu"]
-		_ = dest["sensitive"]
-		_ = dest["sensitive_option"]
-		_ = dest["daily_stock"]
-		_ = dest["info"]
-		_ = dest["warning_level"]
-		_ = dest["free_after_pay"]
-		_ = dest["id_food_group"]
-		_ = dest["article_type"]
-		_ = dest["id_inventory_item"]
-		_ = dest["id_recipe"]
-		_ = dest["id_unity_sales"]
-		_ = dest["can_savepoints"]
-		_ = dest["show_in_kitchen_screen"]
-		_ = dest["decrease_savepoints"]
-		_ = dest["hht_color"]
-		_ = dest["hht_font_name"]
-		_ = dest["hht_font_size"]
-		_ = dest["hht_font_attr"]
-		_ = dest["hht_font_color"]
-		_ = dest["tip"]
-		_ = dest["id_beco_group"]
-		_ = dest["id_beco_location"]
-		_ = dest["bc_standard_dosage"]
-		_ = dest["bc_alternative_dosage"]
-		_ = dest["bc_disablebalance"]
-		_ = dest["bc_use_locations"]
-		_ = dest["time_rate"]
-		_ = dest["id_free_option"]
-		_ = dest["party_article"]
-		_ = dest["id_pua_groups"]
-		_ = dest["promo"]
-		_ = dest["one_hand_limit"]
-		_ = dest["consolidate_quantity"]
-		_ = dest["consolidate_alias_name"]
-		_ = dest["hq_id"]
-		_ = dest["is_active"]
-		_ = dest["is_active_modified"]
-		_ = dest["is_active_modifier"]
-		_ = dest["rent_price_type"]
-		_ = dest["id_rental_group"]
-		_ = dest["condition_check_in_order"]
-		_ = dest["weight_required"]
-		_ = dest["daily_numeric_1"]
-		_ = dest["daily_numeric_2"]
-		_ = dest["prep_min"]
-		_ = dest["id_article_ksp"]
-		_ = dest["warn_min"]
-		_ = dest["empty_article"]
-		_ = dest["bc_debitcredit"]
-		_ = dest["prep_sec"]
-		_ = dest["id_suppliers"]
-		_ = dest["main_price"]
-		_ = dest["oman_text"]
-		_ = dest["id_age_groups"]
-		_ = dest["surcharge"]
-		_ = dest["info_data"]
-		_ = dest["pos_disabled"]
-		_ = dest["ml_name"]
-		_ = dest["ml_ks_name"]
-		_ = dest["alt_articles"]
-		_ = dest["alt_alias"]
-		_ = dest["need_prep"]
-		_ = dest["auto_onhold"]
-		_ = dest["id_ks_wf"]
-		_ = dest["ks_wf_type"]
-		_ = dest["ask_course"]
-		_ = dest["popup_info"]
-		_ = dest["allow_order_items"]
-		_ = dest["must_combined"]
-		_ = dest["block_discount"]
-		_ = dest["has_default_options"]
-		_ = dest["hht_default_setting"]
-		_ = dest["oman_default_setting"]
-		_ = dest["id_rent_periods"]
-		_ = dest["delay_separate_mins"]
-		_ = dest["id_ksc"]
-		_ = dest["ml_pc_text"]
-		_ = dest["ml_rm_text"]
-		_ = dest["ml_oman_text"]
-		_ = dest["pos_article_type"]
-		_ = dest["single_free_option"]
-		_ = dest["ks_single_item"]
-		_ = dest["allergen"]
-		_ = dest["auto_resetcourse"]
-		_ = dest["block_transfer"]
-		_ = dest["id_size_modifier"]
-		dest["quantity"] = 123
-		_, err = json.Marshal(dest)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			dest := map[string]interface{}{}
+			json.Unmarshal(data, &dest)
+			_ = dest["id"]
+			_ = dest["article_number"]
+			_ = dest["name"]
+			_ = dest["internal_name"]
+			_ = dest["article_manual"]
+			_ = dest["article_hash"]
+			_ = dest["id_courses"]
+			_ = dest["id_departament"]
+			_ = dest["pc_bitmap"]
+			_ = dest["pc_color"]
+			_ = dest["pc_text"]
+			_ = dest["pc_font_name"]
+			_ = dest["pc_font_size"]
+			_ = dest["pc_font_attr"]
+			_ = dest["pc_font_color"]
+			_ = dest["rm_text"]
+			_ = dest["rm_font_size"]
+			_ = dest["id_packing"]
+			_ = dest["id_commission"]
+			_ = dest["id_promotions"]
+			_ = dest["savepoints"]
+			_ = dest["quantity"]
+			_ = dest["hideonhold"]
+			_ = dest["barcode"]
+			_ = dest["time_active"]
+			_ = dest["aftermin"]
+			_ = dest["periodmin"]
+			_ = dest["roundmin"]
+			_ = dest["id_currency"]
+			_ = dest["control_active"]
+			_ = dest["control_time"]
+			_ = dest["plu_number_vanduijnen"]
+			_ = dest["sequence"]
+			_ = dest["rm_sequence"]
+			_ = dest["purchase_price"]
+			_ = dest["id_vd_group"]
+			_ = dest["menu"]
+			_ = dest["sensitive"]
+			_ = dest["sensitive_option"]
+			_ = dest["daily_stock"]
+			_ = dest["info"]
+			_ = dest["warning_level"]
+			_ = dest["free_after_pay"]
+			_ = dest["id_food_group"]
+			_ = dest["article_type"]
+			_ = dest["id_inventory_item"]
+			_ = dest["id_recipe"]
+			_ = dest["id_unity_sales"]
+			_ = dest["can_savepoints"]
+			_ = dest["show_in_kitchen_screen"]
+			_ = dest["decrease_savepoints"]
+			_ = dest["hht_color"]
+			_ = dest["hht_font_name"]
+			_ = dest["hht_font_size"]
+			_ = dest["hht_font_attr"]
+			_ = dest["hht_font_color"]
+			_ = dest["tip"]
+			_ = dest["id_beco_group"]
+			_ = dest["id_beco_location"]
+			_ = dest["bc_standard_dosage"]
+			_ = dest["bc_alternative_dosage"]
+			_ = dest["bc_disablebalance"]
+			_ = dest["bc_use_locations"]
+			_ = dest["time_rate"]
+			_ = dest["id_free_option"]
+			_ = dest["party_article"]
+			_ = dest["id_pua_groups"]
+			_ = dest["promo"]
+			_ = dest["one_hand_limit"]
+			_ = dest["consolidate_quantity"]
+			_ = dest["consolidate_alias_name"]
+			_ = dest["hq_id"]
+			_ = dest["is_active"]
+			_ = dest["is_active_modified"]
+			_ = dest["is_active_modifier"]
+			_ = dest["rent_price_type"]
+			_ = dest["id_rental_group"]
+			_ = dest["condition_check_in_order"]
+			_ = dest["weight_required"]
+			_ = dest["daily_numeric_1"]
+			_ = dest["daily_numeric_2"]
+			_ = dest["prep_min"]
+			_ = dest["id_article_ksp"]
+			_ = dest["warn_min"]
+			_ = dest["empty_article"]
+			_ = dest["bc_debitcredit"]
+			_ = dest["prep_sec"]
+			_ = dest["id_suppliers"]
+			_ = dest["main_price"]
+			_ = dest["oman_text"]
+			_ = dest["id_age_groups"]
+			_ = dest["surcharge"]
+			_ = dest["info_data"]
+			_ = dest["pos_disabled"]
+			_ = dest["ml_name"]
+			_ = dest["ml_ks_name"]
+			_ = dest["alt_articles"]
+			_ = dest["alt_alias"]
+			_ = dest["need_prep"]
+			_ = dest["auto_onhold"]
+			_ = dest["id_ks_wf"]
+			_ = dest["ks_wf_type"]
+			_ = dest["ask_course"]
+			_ = dest["popup_info"]
+			_ = dest["allow_order_items"]
+			_ = dest["must_combined"]
+			_ = dest["block_discount"]
+			_ = dest["has_default_options"]
+			_ = dest["hht_default_setting"]
+			_ = dest["oman_default_setting"]
+			_ = dest["id_rent_periods"]
+			_ = dest["delay_separate_mins"]
+			_ = dest["id_ksc"]
+			_ = dest["ml_pc_text"]
+			_ = dest["ml_rm_text"]
+			_ = dest["ml_oman_text"]
+			_ = dest["pos_article_type"]
+			_ = dest["single_free_option"]
+			_ = dest["ks_single_item"]
+			_ = dest["allergen"]
+			_ = dest["auto_resetcourse"]
+			_ = dest["block_transfer"]
+			_ = dest["id_size_modifier"]
+			dest["quantity"] = 123
+			if _, err = json.Marshal(dest); err != nil {
+				b.Fatal(err)
+			}
 		}
-	}
+	})
 }
 
 func BenchmarkWriteDynoBufferArticleReadAllFieldsUntyped(b *testing.B) {
 	s := getArticleSchemeDynoBuffer()
 	bf := dynobuffers.NewBuffer(s)
 	fillArticleDynoBuffer(bf)
-	bytes, _ := bf.ToBytes()
+	bytes, err := bf.ToBytes()
+	require.Nil(b, err)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.ReadBuffer(bytes, s)
-		bf.Get("id")
-		bf.Get("article_number")
-		bf.Get("name")
-		bf.Get("internal_name")
-		bf.Get("article_manual")
-		bf.Get("article_hash")
-		bf.Get("id_courses")
-		bf.Get("id_departament")
-		bf.Get("pc_bitmap")
-		bf.Get("pc_color")
-		bf.Get("pc_text")
-		bf.Get("pc_font_name")
-		bf.Get("pc_font_size")
-		bf.Get("pc_font_attr")
-		bf.Get("pc_font_color")
-		bf.Get("rm_text")
-		bf.Get("rm_font_size")
-		bf.Get("id_packing")
-		bf.Get("id_commission")
-		bf.Get("id_promotions")
-		bf.Get("savepoints")
-		bf.Get("quantity")
-		bf.Get("hideonhold")
-		bf.Get("barcode")
-		bf.Get("time_active")
-		bf.Get("aftermin")
-		bf.Get("periodmin")
-		bf.Get("roundmin")
-		bf.Get("id_currency")
-		bf.Get("control_active")
-		bf.Get("control_time")
-		bf.Get("plu_number_vanduijnen")
-		bf.Get("sequence")
-		bf.Get("rm_sequence")
-		bf.Get("purchase_price")
-		bf.Get("id_vd_group")
-		bf.Get("menu")
-		bf.Get("sensitive")
-		bf.Get("sensitive_option")
-		bf.Get("daily_stock")
-		bf.Get("info")
-		bf.Get("warning_level")
-		bf.Get("free_after_pay")
-		bf.Get("id_food_group")
-		bf.Get("article_type")
-		bf.Get("id_inventory_item")
-		bf.Get("id_recipe")
-		bf.Get("id_unity_sales")
-		bf.Get("can_savepoints")
-		bf.Get("show_in_kitchen_screen")
-		bf.Get("decrease_savepoints")
-		bf.Get("hht_color")
-		bf.Get("hht_font_name")
-		bf.Get("hht_font_size")
-		bf.Get("hht_font_attr")
-		bf.Get("hht_font_color")
-		bf.Get("tip")
-		bf.Get("id_beco_group")
-		bf.Get("id_beco_location")
-		bf.Get("bc_standard_dosage")
-		bf.Get("bc_alternative_dosage")
-		bf.Get("bc_disablebalance")
-		bf.Get("bc_use_locations")
-		bf.Get("time_rate")
-		bf.Get("id_free_option")
-		bf.Get("party_article")
-		bf.Get("id_pua_groups")
-		bf.Get("promo")
-		bf.Get("one_hand_limit")
-		bf.Get("consolidate_quantity")
-		bf.Get("consolidate_alias_name")
-		bf.Get("hq_id")
-		bf.Get("is_active")
-		bf.Get("is_active_modified")
-		bf.Get("is_active_modifier")
-		bf.Get("rent_price_type")
-		bf.Get("id_rental_group")
-		bf.Get("condition_check_in_order")
-		bf.Get("weight_required")
-		bf.Get("daily_numeric_1")
-		bf.Get("daily_numeric_2")
-		bf.Get("prep_min")
-		bf.Get("id_article_ksp")
-		bf.Get("warn_min")
-		bf.Get("empty_article")
-		bf.Get("bc_debitcredit")
-		bf.Get("prep_sec")
-		bf.Get("id_suppliers")
-		bf.Get("main_price")
-		bf.Get("oman_text")
-		bf.Get("id_age_groups")
-		bf.Get("surcharge")
-		bf.Get("info_data")
-		bf.Get("pos_disabled")
-		bf.Get("ml_name")
-		bf.Get("ml_ks_name")
-		bf.Get("alt_articles")
-		bf.Get("alt_alias")
-		bf.Get("need_prep")
-		bf.Get("auto_onhold")
-		bf.Get("id_ks_wf")
-		bf.Get("ks_wf_type")
-		bf.Get("ask_course")
-		bf.Get("popup_info")
-		bf.Get("allow_order_items")
-		bf.Get("must_combined")
-		bf.Get("block_discount")
-		bf.Get("has_default_options")
-		bf.Get("hht_default_setting")
-		bf.Get("oman_default_setting")
-		bf.Get("id_rent_periods")
-		bf.Get("delay_separate_mins")
-		bf.Get("id_ksc")
-		bf.Get("ml_pc_text")
-		bf.Get("ml_rm_text")
-		bf.Get("ml_oman_text")
-		bf.Get("pos_article_type")
-		bf.Get("single_free_option")
-		bf.Get("ks_single_item")
-		bf.Get("allergen")
-		bf.Get("auto_resetcourse")
-		bf.Get("block_transfer")
-		bf.Get("id_size_modifier")
-		bf.Set("quantity", int32(123))
-		_, _ = bf.ToBytes()
-
-		bf.Release()
-	}
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			bf := dynobuffers.ReadBuffer(bytes, s)
+			bf.Get("id")
+			bf.Get("article_number")
+			bf.Get("name")
+			bf.Get("internal_name")
+			bf.Get("article_manual")
+			bf.Get("article_hash")
+			bf.Get("id_courses")
+			bf.Get("id_departament")
+			bf.Get("pc_bitmap")
+			bf.Get("pc_color")
+			bf.Get("pc_text")
+			bf.Get("pc_font_name")
+			bf.Get("pc_font_size")
+			bf.Get("pc_font_attr")
+			bf.Get("pc_font_color")
+			bf.Get("rm_text")
+			bf.Get("rm_font_size")
+			bf.Get("id_packing")
+			bf.Get("id_commission")
+			bf.Get("id_promotions")
+			bf.Get("savepoints")
+			bf.Get("quantity")
+			bf.Get("hideonhold")
+			bf.Get("barcode")
+			bf.Get("time_active")
+			bf.Get("aftermin")
+			bf.Get("periodmin")
+			bf.Get("roundmin")
+			bf.Get("id_currency")
+			bf.Get("control_active")
+			bf.Get("control_time")
+			bf.Get("plu_number_vanduijnen")
+			bf.Get("sequence")
+			bf.Get("rm_sequence")
+			bf.Get("purchase_price")
+			bf.Get("id_vd_group")
+			bf.Get("menu")
+			bf.Get("sensitive")
+			bf.Get("sensitive_option")
+			bf.Get("daily_stock")
+			bf.Get("info")
+			bf.Get("warning_level")
+			bf.Get("free_after_pay")
+			bf.Get("id_food_group")
+			bf.Get("article_type")
+			bf.Get("id_inventory_item")
+			bf.Get("id_recipe")
+			bf.Get("id_unity_sales")
+			bf.Get("can_savepoints")
+			bf.Get("show_in_kitchen_screen")
+			bf.Get("decrease_savepoints")
+			bf.Get("hht_color")
+			bf.Get("hht_font_name")
+			bf.Get("hht_font_size")
+			bf.Get("hht_font_attr")
+			bf.Get("hht_font_color")
+			bf.Get("tip")
+			bf.Get("id_beco_group")
+			bf.Get("id_beco_location")
+			bf.Get("bc_standard_dosage")
+			bf.Get("bc_alternative_dosage")
+			bf.Get("bc_disablebalance")
+			bf.Get("bc_use_locations")
+			bf.Get("time_rate")
+			bf.Get("id_free_option")
+			bf.Get("party_article")
+			bf.Get("id_pua_groups")
+			bf.Get("promo")
+			bf.Get("one_hand_limit")
+			bf.Get("consolidate_quantity")
+			bf.Get("consolidate_alias_name")
+			bf.Get("hq_id")
+			bf.Get("is_active")
+			bf.Get("is_active_modified")
+			bf.Get("is_active_modifier")
+			bf.Get("rent_price_type")
+			bf.Get("id_rental_group")
+			bf.Get("condition_check_in_order")
+			bf.Get("weight_required")
+			bf.Get("daily_numeric_1")
+			bf.Get("daily_numeric_2")
+			bf.Get("prep_min")
+			bf.Get("id_article_ksp")
+			bf.Get("warn_min")
+			bf.Get("empty_article")
+			bf.Get("bc_debitcredit")
+			bf.Get("prep_sec")
+			bf.Get("id_suppliers")
+			bf.Get("main_price")
+			bf.Get("oman_text")
+			bf.Get("id_age_groups")
+			bf.Get("surcharge")
+			bf.Get("info_data")
+			bf.Get("pos_disabled")
+			bf.Get("ml_name")
+			bf.Get("ml_ks_name")
+			bf.Get("alt_articles")
+			bf.Get("alt_alias")
+			bf.Get("need_prep")
+			bf.Get("auto_onhold")
+			bf.Get("id_ks_wf")
+			bf.Get("ks_wf_type")
+			bf.Get("ask_course")
+			bf.Get("popup_info")
+			bf.Get("allow_order_items")
+			bf.Get("must_combined")
+			bf.Get("block_discount")
+			bf.Get("has_default_options")
+			bf.Get("hht_default_setting")
+			bf.Get("oman_default_setting")
+			bf.Get("id_rent_periods")
+			bf.Get("delay_separate_mins")
+			bf.Get("id_ksc")
+			bf.Get("ml_pc_text")
+			bf.Get("ml_rm_text")
+			bf.Get("ml_oman_text")
+			bf.Get("pos_article_type")
+			bf.Get("single_free_option")
+			bf.Get("ks_single_item")
+			bf.Get("allergen")
+			bf.Get("auto_resetcourse")
+			bf.Get("block_transfer")
+			bf.Get("id_size_modifier")
+			bf.Set("quantity", int32(123))
+			if _, err = bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			bf.Release()
+		}
+	})
 }
 
 func BenchmarkWriteDynoBufferArticleReadAllFieldsTyped(b *testing.B) {
 	s := getArticleSchemeDynoBuffer()
 	bf := dynobuffers.NewBuffer(s)
 	fillArticleDynoBuffer(bf)
-	bytes, _ := bf.ToBytes()
+	bytes, err := bf.ToBytes()
+	require.Nil(b, err)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.ReadBuffer(bytes, s)
-		bf.GetLong("id")
-		bf.GetInt("article_number")
-		bf.GetString("name")
-		bf.GetString("internal_name")
-		bf.GetInt("article_manual")
-		bf.GetInt("article_hash")
-		bf.GetLong("id_courses")
-		bf.GetLong("id_departament")
-		bf.GetInt("pc_bitmap")
-		bf.GetInt("pc_color")
-		bf.GetInt("pc_text")
-		bf.GetString("pc_font_name")
-		bf.GetInt("pc_font_size")
-		bf.GetInt("pc_font_attr")
-		bf.GetInt("pc_font_color")
-		bf.GetString("rm_text")
-		bf.GetInt("rm_font_size")
-		bf.GetInt("id_packing")
-		bf.GetLong("id_commission")
-		bf.GetLong("id_promotions")
-		bf.GetInt("savepoints")
-		bf.GetInt("quantity")
-		bf.GetInt("hideonhold")
-		bf.GetInt("barcode")
-		bf.GetInt("time_active")
-		bf.GetInt("aftermin")
-		bf.GetInt("periodmin")
-		bf.GetInt("roundmin")
-		bf.GetLong("id_currency")
-		bf.GetInt("control_active")
-		bf.GetInt("control_time")
-		bf.GetInt("plu_number_vanduijnen")
-		bf.GetInt("sequence")
-		bf.GetInt("rm_sequence")
-		bf.GetFloat("purchase_price")
-		bf.GetLong("id_vd_group")
-		bf.GetInt("menu")
-		bf.GetInt("sensitive")
-		bf.GetInt("sensitive_option")
-		bf.GetInt("daily_stock")
-		bf.GetString("info")
-		bf.GetInt("warning_level")
-		bf.GetInt("free_after_pay")
-		bf.GetLong("id_food_group")
-		bf.GetInt("article_type")
-		bf.GetLong("id_inventory_item")
-		bf.GetLong("id_recipe")
-		bf.GetLong("id_unity_sales")
-		bf.GetInt("can_savepoints")
-		bf.GetBool("show_in_kitchen_screen")
-		bf.GetInt("decrease_savepoints")
-		bf.GetInt("hht_color")
-		bf.GetString("hht_font_name")
-		bf.GetInt("hht_font_size")
-		bf.GetInt("hht_font_attr")
-		bf.GetInt("hht_font_color")
-		bf.GetInt("tip")
-		bf.GetLong("id_beco_group")
-		bf.GetLong("id_beco_location")
-		bf.GetInt("bc_standard_dosage")
-		bf.GetInt("bc_alternative_dosage")
-		bf.GetInt("bc_disablebalance")
-		bf.GetInt("bc_use_locations")
-		bf.GetInt("time_rate")
-		bf.GetLong("id_free_option")
-		bf.GetInt("party_article")
-		bf.GetLong("id_free_option")
-		bf.GetLong("id_pua_groups")
-		bf.GetInt("promo")
-		bf.GetInt("one_hand_limit")
-		bf.GetInt("consolidate_quantity")
-		bf.GetString("consolidate_alias_name")
-		bf.GetInt("hq_id")
-		bf.GetBool("is_active")
-		bf.GetInt("is_active_modified")
-		bf.GetInt("is_active_modifier")
-		bf.GetInt("rent_price_type")
-		bf.GetLong("id_rental_group")
-		bf.GetInt("condition_check_in_order")
-		bf.GetInt("weight_required")
-		bf.GetInt("daily_numeric_1")
-		bf.GetInt("daily_numeric_2")
-		bf.GetInt("prep_min")
-		bf.GetLong("id_article_ksp")
-		bf.GetInt("warn_min")
-		bf.GetInt("empty_article")
-		bf.GetInt("bc_debitcredit")
-		bf.GetInt("prep_sec")
-		bf.GetLong("id_suppliers")
-		bf.GetFloat("main_price")
-		bf.GetString("oman_text")
-		bf.GetLong("id_age_groups")
-		bf.GetInt("surcharge")
-		bf.GetInt("info_data")
-		bf.GetInt("pos_disabled")
-		bf.GetInt("ml_name")
-		bf.GetInt("ml_ks_name")
-		bf.GetInt("alt_articles")
-		bf.GetInt("alt_alias")
-		bf.GetInt("need_prep")
-		bf.GetInt("auto_onhold")
-		bf.GetLong("id_ks_wf")
-		bf.GetInt("ks_wf_type")
-		bf.GetInt("ask_course")
-		bf.GetInt("popup_info")
-		bf.GetInt("allow_order_items")
-		bf.GetInt("must_combined")
-		bf.GetInt("block_discount")
-		bf.GetInt("has_default_options")
-		bf.GetInt("hht_default_setting")
-		bf.GetInt("oman_default_setting")
-		bf.GetLong("id_rent_periods")
-		bf.GetInt("delay_separate_mins")
-		bf.GetLong("id_ksc")
-		bf.GetString("ml_pc_text")
-		bf.GetString("ml_rm_text")
-		bf.GetString("ml_oman_text")
-		bf.GetInt("pos_article_type")
-		bf.GetInt("single_free_option")
-		bf.GetInt("ks_single_item")
-		bf.GetInt("allergen")
-		bf.GetInt("auto_resetcourse")
-		bf.GetInt("block_transfer")
-		bf.GetLong("id_size_modifier")
-		bf.Set("quantity", int32(123))
-		_, _ = bf.ToBytes()
-	}
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			bf := dynobuffers.ReadBuffer(bytes, s)
+			bf.GetLong("id")
+			bf.GetInt("article_number")
+			bf.GetString("name")
+			bf.GetString("internal_name")
+			bf.GetInt("article_manual")
+			bf.GetInt("article_hash")
+			bf.GetLong("id_courses")
+			bf.GetLong("id_departament")
+			bf.GetInt("pc_bitmap")
+			bf.GetInt("pc_color")
+			bf.GetInt("pc_text")
+			bf.GetString("pc_font_name")
+			bf.GetInt("pc_font_size")
+			bf.GetInt("pc_font_attr")
+			bf.GetInt("pc_font_color")
+			bf.GetString("rm_text")
+			bf.GetInt("rm_font_size")
+			bf.GetInt("id_packing")
+			bf.GetLong("id_commission")
+			bf.GetLong("id_promotions")
+			bf.GetInt("savepoints")
+			bf.GetInt("quantity")
+			bf.GetInt("hideonhold")
+			bf.GetInt("barcode")
+			bf.GetInt("time_active")
+			bf.GetInt("aftermin")
+			bf.GetInt("periodmin")
+			bf.GetInt("roundmin")
+			bf.GetLong("id_currency")
+			bf.GetInt("control_active")
+			bf.GetInt("control_time")
+			bf.GetInt("plu_number_vanduijnen")
+			bf.GetInt("sequence")
+			bf.GetInt("rm_sequence")
+			bf.GetFloat("purchase_price")
+			bf.GetLong("id_vd_group")
+			bf.GetInt("menu")
+			bf.GetInt("sensitive")
+			bf.GetInt("sensitive_option")
+			bf.GetInt("daily_stock")
+			bf.GetString("info")
+			bf.GetInt("warning_level")
+			bf.GetInt("free_after_pay")
+			bf.GetLong("id_food_group")
+			bf.GetInt("article_type")
+			bf.GetLong("id_inventory_item")
+			bf.GetLong("id_recipe")
+			bf.GetLong("id_unity_sales")
+			bf.GetInt("can_savepoints")
+			bf.GetBool("show_in_kitchen_screen")
+			bf.GetInt("decrease_savepoints")
+			bf.GetInt("hht_color")
+			bf.GetString("hht_font_name")
+			bf.GetInt("hht_font_size")
+			bf.GetInt("hht_font_attr")
+			bf.GetInt("hht_font_color")
+			bf.GetInt("tip")
+			bf.GetLong("id_beco_group")
+			bf.GetLong("id_beco_location")
+			bf.GetInt("bc_standard_dosage")
+			bf.GetInt("bc_alternative_dosage")
+			bf.GetInt("bc_disablebalance")
+			bf.GetInt("bc_use_locations")
+			bf.GetInt("time_rate")
+			bf.GetLong("id_free_option")
+			bf.GetInt("party_article")
+			bf.GetLong("id_free_option")
+			bf.GetLong("id_pua_groups")
+			bf.GetInt("promo")
+			bf.GetInt("one_hand_limit")
+			bf.GetInt("consolidate_quantity")
+			bf.GetString("consolidate_alias_name")
+			bf.GetInt("hq_id")
+			bf.GetBool("is_active")
+			bf.GetInt("is_active_modified")
+			bf.GetInt("is_active_modifier")
+			bf.GetInt("rent_price_type")
+			bf.GetLong("id_rental_group")
+			bf.GetInt("condition_check_in_order")
+			bf.GetInt("weight_required")
+			bf.GetInt("daily_numeric_1")
+			bf.GetInt("daily_numeric_2")
+			bf.GetInt("prep_min")
+			bf.GetLong("id_article_ksp")
+			bf.GetInt("warn_min")
+			bf.GetInt("empty_article")
+			bf.GetInt("bc_debitcredit")
+			bf.GetInt("prep_sec")
+			bf.GetLong("id_suppliers")
+			bf.GetFloat("main_price")
+			bf.GetString("oman_text")
+			bf.GetLong("id_age_groups")
+			bf.GetInt("surcharge")
+			bf.GetInt("info_data")
+			bf.GetInt("pos_disabled")
+			bf.GetInt("ml_name")
+			bf.GetInt("ml_ks_name")
+			bf.GetInt("alt_articles")
+			bf.GetInt("alt_alias")
+			bf.GetInt("need_prep")
+			bf.GetInt("auto_onhold")
+			bf.GetLong("id_ks_wf")
+			bf.GetInt("ks_wf_type")
+			bf.GetInt("ask_course")
+			bf.GetInt("popup_info")
+			bf.GetInt("allow_order_items")
+			bf.GetInt("must_combined")
+			bf.GetInt("block_discount")
+			bf.GetInt("has_default_options")
+			bf.GetInt("hht_default_setting")
+			bf.GetInt("oman_default_setting")
+			bf.GetLong("id_rent_periods")
+			bf.GetInt("delay_separate_mins")
+			bf.GetLong("id_ksc")
+			bf.GetString("ml_pc_text")
+			bf.GetString("ml_rm_text")
+			bf.GetString("ml_oman_text")
+			bf.GetInt("pos_article_type")
+			bf.GetInt("single_free_option")
+			bf.GetInt("ks_single_item")
+			bf.GetInt("allergen")
+			bf.GetInt("auto_resetcourse")
+			bf.GetInt("block_transfer")
+			bf.GetLong("id_size_modifier")
+			bf.Set("quantity", int32(123))
+			if _, err = bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+
+			bf.Release()
+		}
+	})
 }

--- a/benchmarks/benchWrite_test.go
+++ b/benchmarks/benchWrite_test.go
@@ -27,10 +27,30 @@ func BenchmarkWriteSimple_Dyno_SameBuilder(b *testing.B) {
 		bf.Set("name", "cola")
 		bf.Set("price", float32(0.123))
 		bf.Set("quantity", int32(42))
-		_, err := bf.ToBytesWithBuilder(builder)
+		builder.Reset()
+		err := bf.ToBytesWithBuilder(builder)
 		if err != nil {
 			b.Fatal(err)
 		}
+		bf.Reset(nil)
+	}
+}
+
+func BenchmarkWriteSimple_Dyno_ToBytesBuffered(b *testing.B) {
+	s := getSimpleScheme()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bf := dynobuffers.NewBuffer(s)
+		bf.Set("name", "cola")
+		bf.Set("price", float32(0.123))
+		bf.Set("quantity", int32(42))
+		if bytes, err := bf.ToBytesBuffered(); err != nil {
+			b.Fatal(err)
+		} else {
+			_ = bytes
+		}
+		bf.Release()
 	}
 }
 
@@ -80,7 +100,7 @@ func BenchmarkWriteNestedSimple_Dyno_SameBuilder(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		bf.Reset(nil)
 		bf.ApplyMap(data)
-		_, err := bf.ToBytesWithBuilder(builder)
+		err := bf.ToBytesWithBuilder(builder)
 
 		if err != nil {
 			b.Fatal(err)

--- a/benchmarks/benchWrite_test.go
+++ b/benchmarks/benchWrite_test.go
@@ -9,166 +9,114 @@ package benchmarks
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/linkedin/goavro"
+	"github.com/stretchr/testify/require"
 	"github.com/untillpro/dynobuffers"
 )
 
 func BenchmarkWriteSimple_Dyno_SameBuilder(b *testing.B) {
 	s := getSimpleScheme()
-	bf := dynobuffers.NewBuffer(s)
-	builder := flatbuffers.NewBuilder(0)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bf.Set("name", "cola")
-		bf.Set("price", float32(0.123))
-		bf.Set("quantity", int32(42))
-		builder.Reset()
-		err := bf.ToBytesWithBuilder(builder)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		builder := flatbuffers.NewBuilder(0)
+		for p.Next() {
+			bf := dynobuffers.NewBuffer(s)
+			bf.Set("name", "cola")
+			bf.Set("price", float32(0.123))
+			bf.Set("quantity", int32(42))
+			if err := bf.ToBytesWithBuilder(builder); err != nil {
+				b.Fatal(err)
+			}
+			builder.Reset()
+			bf.Release()
 		}
-		bf.Reset(nil)
-	}
-}
-
-func BenchmarkWriteSimple_Dyno_ToBytesBuffered(b *testing.B) {
-	s := getSimpleScheme()
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.NewBuffer(s)
-		bf.Set("name", "cola")
-		bf.Set("price", float32(0.123))
-		bf.Set("quantity", int32(42))
-		if bytes, err := bf.ToBytesBuffered(); err != nil {
-			b.Fatal(err)
-		} else {
-			_ = bytes
-		}
-		bf.Release()
-	}
+	})
 }
 
 func BenchmarkWriteSimple_Dyno(b *testing.B) {
 	s := getSimpleScheme()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bf := dynobuffers.NewBuffer(s)
-		bf.Set("name", "cola")
-		bf.Set("price", float32(0.123))
-		bf.Set("quantity", int32(42))
-		_, err := bf.ToBytes()
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			bf := dynobuffers.NewBuffer(s)
+			bf.Set("name", "cola")
+			bf.Set("price", float32(0.123))
+			bf.Set("quantity", int32(42))
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			bf.Release()
 		}
-		bf.Release()
-	}
+	})
 }
 
 func BenchmarkWriteNestedSimple_Dyno(b *testing.B) {
 	s := getNestedScheme()
 	data := getNestedData()
-	bf := dynobuffers.NewBuffer(s)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bf.Reset(nil)
-		bf.ApplyMap(data)
-		_, err := bf.ToBytes()
-
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			bf := dynobuffers.NewBuffer(s)
+			if err := bf.ApplyMap(data); err != nil {
+				b.Fatal(err)
+			}
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			bf.Release()
 		}
-	}
+	})
 }
 
 func BenchmarkWriteNestedSimple_Dyno_SameBuilder(b *testing.B) {
 	s := getNestedScheme()
 	data := getNestedData()
-	builder := flatbuffers.NewBuilder(0)
 
-	bf := dynobuffers.NewBuffer(s)
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		bf.Reset(nil)
-		bf.ApplyMap(data)
-		err := bf.ToBytesWithBuilder(builder)
-
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		builder := flatbuffers.NewBuilder(0)
+		for p.Next() {
+			bf := dynobuffers.NewBuffer(s)
+			bf.ApplyMap(data)
+			if err := bf.ToBytesWithBuilder(builder); err != nil {
+				b.Fatal(err)
+			}
+			builder.Reset()
+			bf.Release()
 		}
-	}
+	})
 }
 
 func BenchmarkWriteNestedSimple_ApplyMap_Test(b *testing.B) {
 	s := getNestedScheme()
 	data := getNestedData()
 
-	bf := dynobuffers.NewBuffer(s)
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		bf.Reset(nil)
-		bf.ApplyMap(data)
-		bf.Reset(nil)
-	}
-
-	b.StopTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			bf := dynobuffers.NewBuffer(s)
+			bf.ApplyMap(data)
+			bf.Release()
+		}
+	})
 }
 
 func BenchmarkWriteNested_ToBytes_Test(b *testing.B) {
 	s := getNestedScheme()
 	data := getNestedData()
 
-	bf := dynobuffers.NewBuffer(s)
-
-	bf.ApplyMap(data)
-
 	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		_, err := bf.ToBytes()
-
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-
-	b.StopTimer()
-}
-
-func BenchmarkWriteNested_ToBytes_Parallel(b *testing.B) {
-	s := getNestedScheme()
-	data := getNestedData()
-
-	b.ResetTimer()
-
-	b.RunParallel(func(pb *testing.PB) {
+	b.RunParallel(func(p *testing.PB) {
 		bf := dynobuffers.NewBuffer(s)
-
 		bf.ApplyMap(data)
-
-		for pb.Next() {
-			_, err := bf.ToBytes()
-
-			if err != nil {
+		for p.Next() {
+			if _, err := bf.ToBytes(); err != nil {
 				b.Fatal(err)
 			}
 		}
-
-		bf.Release()
 	})
 
-	b.StopTimer()
 }
 
 func BenchmarkWriteSimple_Avro(b *testing.B) {
@@ -182,36 +130,21 @@ func BenchmarkWriteSimple_Avro(b *testing.B) {
 			{"name": "quantity", "type": "int", "default": 0}
 		]}
 	`)
-	if err != nil {
-		fmt.Println(err)
-	}
+	require.Nil(b, err)
 
 	b.ResetTimer()
-
-	buf := make([]byte, 0)
-	for i := 0; i < b.N; i++ {
-		data := make(map[string]interface{})
-		data["name"] = "cola"
-		data["quantity"] = 1
-		data["price"] = float32(0.123)
-		buf, err = codec.BinaryFromNative(buf[:0], data)
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		buf := make([]byte, 0)
+		for p.Next() {
+			data := make(map[string]interface{})
+			data["name"] = "cola"
+			data["quantity"] = 1
+			data["price"] = float32(0.123)
+			if buf, err = codec.BinaryFromNative(buf[:0], data); err != nil {
+				b.Fatal(err)
+			}
 		}
-	}
-}
-
-func TestWriteNestedSimple_ApplyMap_Test(b *testing.T) {
-	s := getNestedScheme()
-	data := getNestedData()
-
-	bf := dynobuffers.NewBuffer(s)
-
-	for i := 0; i < 1000; i++ {
-		bf.ApplyMap(data)
-		bf.Reset(nil)
-	}
-	bf.Release()
+	})
 }
 
 /*
@@ -245,45 +178,42 @@ var testData = []byte(`
 }
 `)
 
-func BenchmarkWriteNestedSimple_ApplyMap_withUnmarshal_Test(b *testing.B) {
-	d := map[string]interface{}{}
+func BenchmarkWriteNestedSimple_ApplyMap_withJSONUnmarshal(b *testing.B) {
 	s := getNestedScheme()
 
-	bf := dynobuffers.NewBuffer(s)
-
 	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		err := json.Unmarshal(testData, &d)
-
-		if err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			d := map[string]interface{}{}
+			if err := json.Unmarshal(testData, &d); err != nil {
+				b.Fatal(err)
+			}
+			bf := dynobuffers.NewBuffer(s)
+			if err := bf.ApplyMap(d); err != nil {
+				b.Fatal(err)
+			}
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			bf.Release()
 		}
-
-		if err := bf.ApplyMap(d); err != nil {
-			b.Fatal(err)
-		}
-
-		bf.Reset(nil)
-	}
-
-	b.StopTimer()
+	})
 }
 
-func BenchmarkWriteNestedSimple_ApplyMapBuffer_Test(b *testing.B) {
+func BenchmarkWriteNestedSimple_ApplyMapBuffer(b *testing.B) {
 	s := getNestedScheme()
 
-	bf := dynobuffers.NewBuffer(s)
-
 	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		if err := bf.ApplyMapBuffer(testData); err != nil {
-			b.Fatal(err)
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			bf := dynobuffers.NewBuffer(s)
+			if err := bf.ApplyMapBuffer(testData); err != nil {
+				b.Fatal(err)
+			}
+			if _, err := bf.ToBytes(); err != nil {
+				b.Fatal(err)
+			}
+			bf.Release()
 		}
-
-		bf.Reset(nil)
-	}
-
-	b.StopTimer()
+	})
 }

--- a/dynostorage.go
+++ b/dynostorage.go
@@ -24,18 +24,22 @@ type offset struct {
 
 // Begin pools
 
-var builderPool = sync.Pool{
-	New: func() interface{} { return flatbuffers.NewBuilder(0) },
-}
-
-var bufferPool = sync.Pool{
-	New: func() interface{} {
-		return &Buffer{
-			builder:        flatbuffers.NewBuilder(0),
-			modifiedFields: make([]*modifiedField, defaultBufferSize),
-		}
-	},
-}
+var (
+	builderPool = sync.Pool{
+		New: func() interface{} { return flatbuffers.NewBuilder(0) },
+	}
+	bufferPool = sync.Pool{
+		New: func() interface{} {
+			return &Buffer{
+				builder:        flatbuffers.NewBuilder(0),
+				modifiedFields: make([]*modifiedField, defaultBufferSize),
+			}
+		},
+	}
+	objectArrayPool = sync.Pool{
+		New: func() interface{} { return &ObjectArray{} },
+	}
+)
 
 func getBuffer() (b *Buffer) {
 	b = bufferPool.Get().(*Buffer)

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/untillpro/dynobuffers
 go 1.14
 
 require (
-	github.com/untillpro/gojay v1.2.16
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/flatbuffers v1.12.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/linkedin/goavro v2.1.0+incompatible
 	github.com/stretchr/testify v1.6.1
+	github.com/untillpro/gojay v1.2.17-0.20201031112155-f7a39177377e
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -20,7 +20,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
-github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -115,10 +114,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/untillpro/gojay v1.2.15 h1:DnvivUhy9xB8/WGbpU44AfyViPL2iaawGPsqv7EQ1Ks=
-github.com/untillpro/gojay v1.2.15/go.mod h1:wHiWFBGIA2fG/tCRDfHII3S8LW1+DB1SEx4UinSXwdM=
-github.com/untillpro/gojay v1.2.16 h1:w7wsq0nVkIXTk2zV7wbm7hissKHfdv5BcNxyRxZO88Q=
-github.com/untillpro/gojay v1.2.16/go.mod h1:wHiWFBGIA2fG/tCRDfHII3S8LW1+DB1SEx4UinSXwdM=
+github.com/untillpro/gojay v1.2.17-0.20201031112155-f7a39177377e h1:8soOoUBgYeuk40ynYD6S5rJAekog4m4m3lvd3uiu2No=
+github.com/untillpro/gojay v1.2.17-0.20201031112155-f7a39177377e/go.mod h1:wHiWFBGIA2fG/tCRDfHII3S8LW1+DB1SEx4UinSXwdM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=


### PR DESCRIPTION
- using new alloc-free gojay methods to read values, objects, arrays and array elements which could be null

- empty strings are not stored. `Get()` return nil instead of an empty string
- strings stored as byte arrays. Could be `Set()` as both `string` and `[]byte`. `Get*()`, `ToJSON()`, `ToJSONMap()` returns strings as strings
- pooled ObjectArray
- all benchmarks are switched to parallel
- various fixes, optimizations and refactorings