### PR TITLE
Objects pooling and releasing fix, objects in use tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
 - Return `Buffer` to pool to prevent additional memory allocations
   ```go
   b.Release()
-  // note: b itself and result of b.ToBytes() must not be used from now on.
+  // b itself, all objects created manually and used in b.Set(), all objects got using `b.Get()` are released also. Nor these objects neither result of `b.ToBytes()` must not be used from now on
   ```
 - Iterate over fields which has value
   ```go
@@ -269,9 +269,7 @@
 		// arr.Buffer is switched on each arr.Next()
 		assert.Equal(t, int32(1), arr.Buffer.Get("nes1"))
 	}
-	// do not forget to return arr to pool to prevent additional memory allocations
-	arr.Release()
-	// note: arr itself, arr.Buffer, result of arr.Buffer.ToBytes() are obsolete here
+	// note: not need to release `arr`. It will be released on `b.Release()`
 	```
 - Modify array and to bytes
 	- Set

--- a/benchmarks/benchReadWrite_test.go
+++ b/benchmarks/benchReadWrite_test.go
@@ -27,6 +27,8 @@ func Benchmark_RW_Simple_Dyno_Typed(b *testing.B) {
 	bf.Set("quantity", int32(42))
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -44,6 +46,7 @@ func Benchmark_RW_Simple_Dyno_Typed(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_RW_Simple_Dyno_Typed_String(b *testing.B) {
@@ -54,6 +57,8 @@ func Benchmark_RW_Simple_Dyno_Typed_String(b *testing.B) {
 	bf.Set("quantity", int32(42))
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -72,6 +77,7 @@ func Benchmark_RW_Simple_Dyno_Typed_String(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_RW_Simple_Dyno_Untyped(b *testing.B) {
@@ -82,6 +88,8 @@ func Benchmark_RW_Simple_Dyno_Untyped(b *testing.B) {
 	bf.Set("quantity", int32(42))
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -98,6 +106,7 @@ func Benchmark_RW_Simple_Dyno_Untyped(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_RW_Simple_Flat(b *testing.B) {
@@ -203,6 +212,8 @@ func Benchmark_RW_Article_FewFields_Dyno_Typed(b *testing.B) {
 	fillArticleDynoBuffer(bf)
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -219,6 +230,7 @@ func Benchmark_RW_Article_FewFields_Dyno_Typed(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 func Benchmark_RW_Article_FewFields_Flat(b *testing.B) {
 	bl := flatbuffers.NewBuilder(0)
@@ -265,6 +277,8 @@ func Benchmark_RW_Article_FewFields_Json(b *testing.B) {
 			}
 		}
 	})
+	bf.Release()
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_RW_Article_FewFields_Avro(b *testing.B) {
@@ -589,6 +603,8 @@ func Benchmark_RW_Article_AllFields_Dyno_Untyped(b *testing.B) {
 	fillArticleDynoBuffer(bf)
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -724,6 +740,7 @@ func Benchmark_RW_Article_AllFields_Dyno_Untyped(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_RW_Article_AllFields_Dyno_Typed(b *testing.B) {
@@ -732,6 +749,8 @@ func Benchmark_RW_Article_AllFields_Dyno_Typed(b *testing.B) {
 	fillArticleDynoBuffer(bf)
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -868,4 +887,5 @@ func Benchmark_RW_Article_AllFields_Dyno_Typed(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }

--- a/benchmarks/benchRead_test.go
+++ b/benchmarks/benchRead_test.go
@@ -26,6 +26,8 @@ func Benchmark_R_Simple_Dyno_Typed_String(b *testing.B) {
 	bf.Set("quantity", int32(42))
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -39,6 +41,7 @@ func Benchmark_R_Simple_Dyno_Typed_String(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_R_Simple_Dyno_Untyped(b *testing.B) {
@@ -49,6 +52,8 @@ func Benchmark_R_Simple_Dyno_Untyped(b *testing.B) {
 	bf.Set("quantity", int32(42))
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -61,6 +66,7 @@ func Benchmark_R_Simple_Dyno_Untyped(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_MapToBytes_ArraysAppend_Dyno(b *testing.B) {
@@ -82,6 +88,8 @@ intsObj..:
 	buf := dynobuffers.NewBuffer(s)
 	bytes, _, err := buf.ApplyJSONAndToBytes([]byte(`{"ints":[1,2],"longs":[3,4],"floats":[0.123,0.124],"doubles":[0.125,0.126],"strings":["str1","str2"],"boolTrues":[true,false],"boolFalses":[false,true],"bytes":"BQY="}`))
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	buf.Release()
 
 	dest := map[string]interface{}{}
 	jsonBytes := []byte(`{"ints":[-1,-2],"longs":[-3,-4],"floats":[-0.123,-0.124],"doubles":[-0.125,-0.126],"strings":["","str4"],"boolTrues":[true,true],"boolFalses":[false,false],"bytes":"BQY="}`)
@@ -100,6 +108,7 @@ intsObj..:
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_MapToBytes_ArraysAppendNested_Dyno(b *testing.B) {
@@ -120,6 +129,8 @@ intsObj..:
 	buf := dynobuffers.NewBuffer(s)
 	bytes, _, err := buf.ApplyJSONAndToBytes([]byte(`{"ints":[1,2],"longs":[3,4],"floats":[0.123,0.124],"doubles":[0.125,0.126],"strings":["str1","str2"],"boolTrues":[true,false],"boolFalses":[false,true],"bytes":"BQY=","intsObj":[{"int":7},{"int":8}]}`))
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	buf.Release()
 
 	dest := map[string]interface{}{}
 	jsonBytes := []byte(`{"ints":[-1,-2],"longs":[-3,-4],"floats":[-0.123,-0.124],"doubles":[-0.125,-0.126],"strings":["","str4"],"boolTrues":[true,true],"boolFalses":[false,false],"bytes":"BQY=","intsObj":[{"int":-7},{"int":-8}]}`)
@@ -138,6 +149,7 @@ intsObj..:
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_R_Simple_Avro(b *testing.B) {
@@ -183,6 +195,8 @@ func Benchmark_R_Simple_Dyno_Typed(b *testing.B) {
 	bf.Set("quantity", int32(42))
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -195,6 +209,7 @@ func Benchmark_R_Simple_Dyno_Typed(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 func Benchmark_R_Simple_Flat(b *testing.B) {
 	bl := flatbuffers.NewBuilder(0)
@@ -297,6 +312,8 @@ func Benchmark_R_Article_FewFields_Dyno_Typed(b *testing.B) {
 	bf := dynobuffers.NewBuffer(s)
 	fillArticleDynoBuffer(bf)
 	bytes, _ := bf.ToBytes()
+	bytes = copyBytes(bytes)
+	bf.Release()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
 		sum := float64(0)
@@ -308,6 +325,7 @@ func Benchmark_R_Article_FewFields_Dyno_Typed(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 func Benchmark_R_Article_FewFields_Flat(b *testing.B) {
 	bl := flatbuffers.NewBuilder(0)
@@ -344,6 +362,8 @@ func Benchmark_R_Article_FewFields_Json(b *testing.B) {
 			sum += q * price
 		}
 	})
+	bf.Release()
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_R_Article_AllFields_Avro(b *testing.B) {
@@ -503,6 +523,8 @@ func Benchmark_R_Article_AllFields_Dyno_Untyped(b *testing.B) {
 	fillArticleDynoBuffer(bf)
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
@@ -634,6 +656,7 @@ func Benchmark_R_Article_AllFields_Dyno_Untyped(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_R_Article_AllFields_Dyno_Typed(b *testing.B) {
@@ -642,6 +665,8 @@ func Benchmark_R_Article_AllFields_Dyno_Typed(b *testing.B) {
 	fillArticleDynoBuffer(bf)
 	bytes, err := bf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	bf.Release()
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
@@ -774,6 +799,7 @@ func Benchmark_R_Article_AllFields_Dyno_Typed(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 func Benchmark_R_Article_AllFields_Flat(b *testing.B) {
 	bl := flatbuffers.NewBuilder(0)

--- a/benchmarks/benchWrite_test.go
+++ b/benchmarks/benchWrite_test.go
@@ -34,6 +34,7 @@ func Benchmark_Fill_ToBytes_Simple_Dyno_SameBuilder(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_Fill_ToBytes_Simple_Dyno(b *testing.B) {
@@ -51,6 +52,7 @@ func Benchmark_Fill_ToBytes_Simple_Dyno(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_MapToBytes_Nested_Dyno(b *testing.B) {
@@ -69,6 +71,7 @@ func Benchmark_MapToBytes_Nested_Dyno(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_MapToBytes_Nested_Dyno_SameBuilder(b *testing.B) {
@@ -87,6 +90,7 @@ func Benchmark_MapToBytes_Nested_Dyno_SameBuilder(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_MapToBytes_Simple_Avro(b *testing.B) {
@@ -133,6 +137,7 @@ func Benchmark_JSONToBytes_Nested_Dyno(b *testing.B) {
 			bf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_JSONToBytes_Simple_Dyno(b *testing.B) {
@@ -148,6 +153,7 @@ func Benchmark_JSONToBytes_Simple_Dyno(b *testing.B) {
 			buf.Release()
 		}
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 func Benchmark_JSONToBytes_Simple_Avro(b *testing.B) {
 	codec, err := goavro.NewCodec(`
@@ -211,6 +217,7 @@ func Benchmark_Fill_ToBytes_Read_Simple_Dyno(bench *testing.B) {
 			b.Release()
 		}
 	})
+	require.Zero(bench, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_ToJSON_Simple_Dyno(b *testing.B) {
@@ -226,6 +233,8 @@ func Benchmark_ToJSON_Simple_Dyno(b *testing.B) {
 	buf.Set("quantity", int32(42))
 	bytes, err := buf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	buf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -235,6 +244,7 @@ func Benchmark_ToJSON_Simple_Dyno(b *testing.B) {
 		}
 		buf.Release()
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
 }
 
 func Benchmark_ToJSONMap_Simple_Dyno(b *testing.B) {
@@ -250,6 +260,8 @@ func Benchmark_ToJSONMap_Simple_Dyno(b *testing.B) {
 	buf.Set("quantity", int32(42))
 	bytes, err := buf.ToBytes()
 	require.Nil(b, err)
+	bytes = copyBytes(bytes)
+	buf.Release()
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
@@ -259,4 +271,11 @@ func Benchmark_ToJSONMap_Simple_Dyno(b *testing.B) {
 		}
 		buf.Release()
 	})
+	require.Zero(b, dynobuffers.GetObjectsInUse())
+}
+
+func copyBytes(src []byte) []byte {
+	res := make([]byte, len(src))
+	copy(res, src)
+	return res
 }

--- a/benchmarks/mem_test.go
+++ b/benchmarks/mem_test.go
@@ -54,6 +54,9 @@ func Test_MemFewArticleFields_Dyno(t *testing.T) {
 	bytes, err = bf.ToBytes()
 	require.Nil(t, err)
 	log.Println("Buffer len for quantity, purchase_price, id, article_number:", len(bytes))
+
+	bf.Release()
+	require.Zero(t, dynobuffers.GetObjectsInUse())
 }
 
 func Test_MemAllArticleFields_Avro(t *testing.T) {

--- a/benchmarks/mem_test.go
+++ b/benchmarks/mem_test.go
@@ -85,4 +85,6 @@ func Test_MemAllArticleFields_Dyno(t *testing.T) {
 	require.Nil(t, err)
 
 	log.Println("MemAllArticleFields_Dyno:", len(bytes))
+	bf.Release()
+	require.Zero(t, dynobuffers.GetObjectsInUse())
 }

--- a/dynobuffers.go
+++ b/dynobuffers.go
@@ -901,15 +901,16 @@ func (b *Buffer) ToBytes() ([]byte, error) {
 	}
 
 	b.builder.Reset()
-	prevHead := b.builder.Head()
 
-	if err := b.ToBytesWithBuilder(b.builder); err != nil {
+	uOffset, err := b.encodeBuffer(b.builder)
+	if err != nil {
 		return nil, err
 	}
 
-	if prevHead != b.builder.Head() {
+	if uOffset != 0 {
 		return b.builder.FinishedBytes(), nil
 	}
+	
 	return nil, nil
 }
 

--- a/dynobuffers.go
+++ b/dynobuffers.go
@@ -910,7 +910,7 @@ func (b *Buffer) ToBytes() ([]byte, error) {
 	if uOffset != 0 {
 		return b.builder.FinishedBytes(), nil
 	}
-	
+
 	return nil, nil
 }
 

--- a/dynobuffers.go
+++ b/dynobuffers.go
@@ -560,6 +560,7 @@ func (b *Buffer) ApplyMapBuffer(jsonMap []byte) error {
 	if len(jsonMap) == 0 {
 		return nil
 	}
+	b.prepareModifiedFields()
 	return gojay.UnmarshalJSONObjectWithPool(jsonMap[:], b)
 }
 
@@ -909,7 +910,6 @@ func (b *Buffer) ToBytes() ([]byte, error) {
 	if prevHead != b.builder.Head() {
 		return b.builder.FinishedBytes(), nil
 	}
-
 	return nil, nil
 }
 

--- a/dynobuffers_test.go
+++ b/dynobuffers_test.go
@@ -2246,7 +2246,6 @@ func mapFromArray(strs []string) map[string]struct{} {
 	return res
 }
 
-// https://github.com/golang/go/issues/40701
 func Benchmark_RW_Nested(b *testing.B) {
 	sNested := NewScheme()
 	sNested.AddField("int", FieldTypeInt, false)

--- a/dynobuffers_test.go
+++ b/dynobuffers_test.go
@@ -9,6 +9,7 @@ package dynobuffers
 
 import (
 	"encoding/json"
+	"log"
 	"reflect"
 	"testing"
 
@@ -2135,6 +2136,7 @@ func TestIterateFields(t *testing.T) {
 		"double": 0.125, "byte": 6, "boolTrue": true, "boolFalse": false,
 		"nested1": {"price": 0.126,"quantity":44}, "nested2": {"price": 0.127,"quantity":45}, "nil": null}`))
 	require.Nil(t, err)
+	log.Println(len(bytes))
 	bytes = copyBytes(bytes)
 	b.Release()
 	require.Equal(t, []string{"nil"}, nilled)

--- a/dynobuffers_test.go
+++ b/dynobuffers_test.go
@@ -2241,6 +2241,7 @@ func TestGetNestedScheme(t *testing.T) {
 }
 
 func TestPreviousResultDamageOnReuse(t *testing.T) {
+	t.Skip("unstable. Use as an example only")
 	s, err := YamlToScheme(schemeStr)
 	require.Nil(t, err)
 	b := NewBuffer(s)
@@ -2258,13 +2259,8 @@ func TestPreviousResultDamageOnReuse(t *testing.T) {
 
 	b.Set("name", "str")
 	b.Set("quantity", 43)
-	for i := 0; i < 10; i++ {
-		_, err = b.ToBytes() // bytes1 should be damaged here (sometimes not, try 10 times)
-		require.Nil(t, err)
-		if reflect.DeepEqual(bytes1, bytes1Copy) {
-			break
-		}
-	}
+	_, err = b.ToBytes() // bytes1 damaged here
+	require.Nil(t, err)
 	require.NotEqual(t, bytes1, bytes1Copy)
 
 	b.Release()

--- a/dynobuffers_test.go
+++ b/dynobuffers_test.go
@@ -9,7 +9,6 @@ package dynobuffers
 
 import (
 	"encoding/json"
-	"log"
 	"reflect"
 	"testing"
 
@@ -2136,7 +2135,6 @@ func TestIterateFields(t *testing.T) {
 		"double": 0.125, "byte": 6, "boolTrue": true, "boolFalse": false,
 		"nested1": {"price": 0.126,"quantity":44}, "nested2": {"price": 0.127,"quantity":45}, "nil": null}`))
 	require.Nil(t, err)
-	log.Println(len(bytes))
 	bytes = copyBytes(bytes)
 	b.Release()
 	require.Equal(t, []string{"nil"}, nilled)

--- a/dynobuffers_test.go
+++ b/dynobuffers_test.go
@@ -2267,32 +2267,6 @@ func TestPreviousResultDamageOnReuse(t *testing.T) {
 	require.Zero(t, GetObjectsInUse())
 }
 
-func TestReuse(t *testing.T) {
-	s, err := YamlToScheme(schemeStr)
-	require.Nil(t, err)
-
-	// borrow a Buffer and fill it
-	b := NewBuffer(s)
-	b.Set("name", "cola")
-	b.Set("price", float32(0.123))
-	b.Set("quantity", int32(42))
-	bytes, err := b.ToBytes()
-	require.Nil(t, err)
-	bytesNew := make([]byte, len(bytes))
-	copy(bytesNew, bytes)
-
-	b.Release() // `bytes` becomes obsolete here
-
-	// borrow one more
-	b = ReadBuffer(bytesNew, s)
-
-	require.Equal(t, "cola", b.Get("name"))
-	require.Equal(t, float32(0.123), b.Get("price"))
-	require.Equal(t, int32(42), b.Get("quantity"))
-	b.Release()
-	require.Zero(t, GetObjectsInUse())
-}
-
 func TestRelease(t *testing.T) {
 	s, err := YamlToScheme(allTypesYaml)
 	require.Nil(t, err)

--- a/dynostorage.go
+++ b/dynostorage.go
@@ -9,12 +9,21 @@ package dynobuffers
 
 import (
 	"sync"
+	"sync/atomic"
 
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/untillpro/gojay"
 )
 
 const defaultBufferSize = 10
+
+var (
+	buffersInUse      uint64
+	bufferSlicesInUse uint64
+	uOffsetsInUse     uint64
+	offsetsInUse      uint64
+	objectArraysInUse uint64
+)
 
 type offset struct {
 	str flatbuffers.UOffsetT
@@ -39,15 +48,38 @@ var (
 	objectArrayPool = sync.Pool{
 		New: func() interface{} { return &ObjectArray{} },
 	}
+	uOffsetPool = sync.Pool{
+		New: func() interface{} {
+			return &uOffsetSlice{
+				Slice: make([]flatbuffers.UOffsetT, defaultBufferSize),
+			}
+		},
+	}
+	offsetPool = sync.Pool{
+		New: func() interface{} {
+			return &offsetSlice{
+				Slice: make([]offset, defaultBufferSize),
+			}
+		},
+	}
+	buffersPool = sync.Pool{
+		New: func() interface{} {
+			return &buffersSlice{
+				Slice: make([]*Buffer, defaultBufferSize),
+			}
+		},
+	}
 )
 
 func getBuffer() (b *Buffer) {
 	b = bufferPool.Get().(*Buffer)
+	atomic.AddUint64(&buffersInUse, 1)
 	return
 }
 
 func putBuffer(b *Buffer) {
 	bufferPool.Put(b)
+	atomic.AddUint64(&buffersInUse, ^uint64(0))
 }
 
 //getUOffsetSlice
@@ -56,16 +88,9 @@ type uOffsetSlice struct {
 	Slice []flatbuffers.UOffsetT
 }
 
-var uOffsetPool = sync.Pool{
-	New: func() interface{} {
-		return &uOffsetSlice{
-			Slice: make([]flatbuffers.UOffsetT, defaultBufferSize),
-		}
-	},
-}
-
 func getUOffsetSlice(l int) (c *uOffsetSlice) {
 	c = uOffsetPool.Get().(*uOffsetSlice)
+	atomic.AddUint64(&uOffsetsInUse, 1)
 
 	if cap(c.Slice) < l {
 		c.Slice = make([]flatbuffers.UOffsetT, l)
@@ -81,6 +106,7 @@ func getUOffsetSlice(l int) (c *uOffsetSlice) {
 
 func putUOffsetSlice(c *uOffsetSlice) {
 	uOffsetPool.Put(c)
+	atomic.AddUint64(&uOffsetsInUse, ^uint64(0))
 }
 
 //getUOffsetSlice
@@ -89,16 +115,9 @@ type offsetSlice struct {
 	Slice []offset
 }
 
-var offsetPool = sync.Pool{
-	New: func() interface{} {
-		return &offsetSlice{
-			Slice: make([]offset, defaultBufferSize),
-		}
-	},
-}
-
 func getOffsetSlice(l int) (c *offsetSlice) {
 	c = offsetPool.Get().(*offsetSlice)
+	atomic.AddUint64(&offsetsInUse, 1)
 
 	if cap(c.Slice) < l {
 		c.Slice = make([]offset, l)
@@ -114,15 +133,16 @@ func getOffsetSlice(l int) (c *offsetSlice) {
 
 func putOffsetSlice(c *offsetSlice) {
 	offsetPool.Put(c)
+	atomic.AddUint64(&offsetsInUse, ^uint64(0))
 }
 
 //getUOffsetSlice
 
 type buffersSlice struct {
-	Slice []*Buffer
-
-	Owner  *Buffer
-	Scheme *Scheme
+	Slice      []*Buffer
+	Owner      *Buffer
+	Scheme     *Scheme
+	isReleased bool
 }
 
 func (b *buffersSlice) UnmarshalJSONArray(dec *gojay.Decoder) error {
@@ -130,6 +150,7 @@ func (b *buffersSlice) UnmarshalJSONArray(dec *gojay.Decoder) error {
 	buffer.owner = b.Owner
 
 	if err := dec.Object(buffer); err != nil {
+		buffer.Release()
 		return err
 	}
 
@@ -138,17 +159,28 @@ func (b *buffersSlice) UnmarshalJSONArray(dec *gojay.Decoder) error {
 	return nil
 }
 
-var buffersPool = sync.Pool{
-	New: func() interface{} {
-		return &buffersSlice{
-			Slice: make([]*Buffer, defaultBufferSize),
+func (b *buffersSlice) Release() {
+	if b.isReleased {
+		return
+	}
+	for _, buf := range b.Slice {
+		// could be nil e.g. if errors during ApplyMap(): got from pool with lenght 2, 1 ok, second - failed to encode
+		if buf != nil {
+			buf.Release()
 		}
-	},
+	}
+	b.Scheme = nil
+	b.Owner = nil
+	b.isReleased = true
+	buffersPool.Put(b)
+	atomic.AddUint64(&bufferSlicesInUse, ^uint64(0))
 }
 
 func getBufferSlice(l int) (b *buffersSlice) {
 	b = buffersPool.Get().(*buffersSlice)
+	atomic.AddUint64(&bufferSlicesInUse, 1)
 
+	b.isReleased = false
 	if cap(b.Slice) < l {
 		b.Slice = make([]*Buffer, l)
 	} else {
@@ -158,13 +190,27 @@ func getBufferSlice(l int) (b *buffersSlice) {
 			b.Slice[k] = nil
 		}
 	}
-
 	return
 }
 
-func putBufferSlice(b *buffersSlice) {
-	b.Scheme = nil
-	b.Owner = nil
+func getObjectArray() *ObjectArray {
+	res := objectArrayPool.Get().(*ObjectArray)
+	res.isReleased = false
+	atomic.AddUint64(&objectArraysInUse, 1)
+	return res
+}
 
-	buffersPool.Put(b)
+func putObjectArray(oa *ObjectArray) {
+	objectArrayPool.Put(oa)
+	atomic.AddUint64(&objectArraysInUse, ^uint64(0))
+}
+
+// GetObjectsInUse returns pooled objects amount which are currently in use, i.e. not released
+// useful for testing and metrics accounting
+func GetObjectsInUse() uint64 {
+	return atomic.LoadUint64(&bufferSlicesInUse) +
+		atomic.LoadUint64(&buffersInUse) +
+		atomic.LoadUint64(&offsetsInUse) +
+		atomic.LoadUint64(&uOffsetsInUse) +
+		atomic.LoadUint64(&objectArraysInUse)
 }

--- a/dynostorage.go
+++ b/dynostorage.go
@@ -34,9 +34,6 @@ type offset struct {
 // Begin pools
 
 var (
-	builderPool = sync.Pool{
-		New: func() interface{} { return flatbuffers.NewBuilder(0) },
-	}
 	bufferPool = sync.Pool{
 		New: func() interface{} {
 			return &Buffer{
@@ -50,16 +47,12 @@ var (
 	}
 	uOffsetPool = sync.Pool{
 		New: func() interface{} {
-			return &uOffsetSlice{
-				Slice: make([]flatbuffers.UOffsetT, defaultBufferSize),
-			}
+			return make([]flatbuffers.UOffsetT, defaultBufferSize)
 		},
 	}
 	offsetPool = sync.Pool{
 		New: func() interface{} {
-			return &offsetSlice{
-				Slice: make([]offset, defaultBufferSize),
-			}
+			return make([]offset, defaultBufferSize)
 		},
 	}
 	buffersPool = sync.Pool{
@@ -83,55 +76,48 @@ func putBuffer(b *Buffer) {
 }
 
 //getUOffsetSlice
+// []flatbuffers.UOffsetT
 
-type uOffsetSlice struct {
-	Slice []flatbuffers.UOffsetT
-}
-
-func getUOffsetSlice(l int) (c *uOffsetSlice) {
-	c = uOffsetPool.Get().(*uOffsetSlice)
+func getUOffsetSlice(l int) (c []flatbuffers.UOffsetT) {
+	c = uOffsetPool.Get().([]flatbuffers.UOffsetT)
 	atomic.AddUint64(&uOffsetsInUse, 1)
 
-	if cap(c.Slice) < l {
-		c.Slice = make([]flatbuffers.UOffsetT, l)
+	if cap(c) < l {
+		c = make([]flatbuffers.UOffsetT, l)
 	} else {
-		c.Slice = c.Slice[:l]
+		c = c[:l]
 
-		for k := range c.Slice {
-			c.Slice[k] = 0
+		for k := range c {
+			c[k] = 0
 		}
 	}
 	return
 }
 
-func putUOffsetSlice(c *uOffsetSlice) {
+func putUOffsetSlice(c []flatbuffers.UOffsetT) {
 	uOffsetPool.Put(c)
 	atomic.AddUint64(&uOffsetsInUse, ^uint64(0))
 }
 
 //getUOffsetSlice
 
-type offsetSlice struct {
-	Slice []offset
-}
-
-func getOffsetSlice(l int) (c *offsetSlice) {
-	c = offsetPool.Get().(*offsetSlice)
+func getOffsetSlice(l int) (c []offset) {
+	c = offsetPool.Get().([]offset)
 	atomic.AddUint64(&offsetsInUse, 1)
 
-	if cap(c.Slice) < l {
-		c.Slice = make([]offset, l)
+	if cap(c) < l {
+		c = make([]offset, l)
 	} else {
-		c.Slice = c.Slice[:l]
+		c = c[:l]
 
-		for k := range c.Slice {
-			c.Slice[k] = offset{}
+		for k := range c {
+			c[k] = offset{}
 		}
 	}
 	return
 }
 
-func putOffsetSlice(c *offsetSlice) {
+func putOffsetSlice(c []offset) {
 	offsetPool.Put(c)
 	atomic.AddUint64(&offsetsInUse, ^uint64(0))
 }


### PR DESCRIPTION
Release() now releases the buffer itself, all objects created during ToBytes, ApplyJSON, ApplyMap etc and objects which were created manually and applied to the buffer somehow e.g. used in Set(). By one word, one Release() to release everything